### PR TITLE
missing fullname & rom extensions for lr-vemulator

### DIFF
--- a/scriptmodules/libretrocores/lr-vemulator.sh
+++ b/scriptmodules/libretrocores/lr-vemulator.sh
@@ -39,5 +39,5 @@ function configure_lr-vemulator() {
     ensureSystemretroconfig "vmu"
 
     addEmulator 1 "$md_id" "vmu" "$md_inst/vemulator_libretro.so"
-    addSystem "vmu"
+    addSystem "vmu" "Visual Memory Unit" ".dci .vms .bin"
 }


### PR DESCRIPTION
this will fix the missing fullname and extensions for lr-vemulator