### PR TITLE
A few more updates to buffer script.

### DIFF
--- a/scriptmodules/ports/sorr.sh
+++ b/scriptmodules/ports/sorr.sh
@@ -33,6 +33,7 @@ pushd "$romdir/ports/$md_id"
 "$md_inst/bgdi-333" \$*
 popd
 _EOF_
+
     chmod +x "$script"
     addPort "bgdi-333" "sorr" "Streets of Rage Remake" "XINIT:$script %ROM%" "./SorR.dat"
     [[ -f "$romdir/ports/$md_id/SorMaker.dat" || "$md_mode" == "remove" ]] && addPort "bgdi-333" "sorr" "SorMaker" "XINIT:$script %ROM%" "./SorMaker.dat"

--- a/scriptmodules/ports/sorr.sh
+++ b/scriptmodules/ports/sorr.sh
@@ -33,7 +33,6 @@ function configure_sorr() {
     [[ "$md_mode" == "remove" ]] && return
 
     #create buffer script for launch
-
     cat > "$script" << _EOF_
 #!/bin/bash
 pushd "$romdir/ports/$md_id"

--- a/scriptmodules/ports/sorr.sh
+++ b/scriptmodules/ports/sorr.sh
@@ -33,7 +33,6 @@ pushd "$romdir/ports/$md_id"
 "$md_inst/bgdi-333" \$*
 popd
 _EOF_
-    chown $user:$user "$script"
     chmod +x "$script"
     addPort "bgdi-333" "sorr" "Streets of Rage Remake" "XINIT:$script %ROM%" "./SorR.dat"
     [[ -f "$romdir/ports/$md_id/SorMaker.dat" || "$md_mode" == "remove" ]] && addPort "bgdi-333" "sorr" "SorMaker" "XINIT:$script %ROM%" "./SorMaker.dat"

--- a/scriptmodules/ports/sorr.sh
+++ b/scriptmodules/ports/sorr.sh
@@ -25,12 +25,15 @@ function install_bin_sorr() {
 }
 
 function configure_sorr() {
+    local script="$md_inst/$md_id.sh"
+    local config="$romdir/ports/$md_id/mod/system.txt"
+
     addPort "bgdi-333" "sorr" "Streets of Rage Remake" "XINIT:$script %ROM%" "./SorR.dat"
     [[ -f "$romdir/ports/$md_id/SorMaker.dat" || "$md_mode" == "remove" ]] && addPort "bgdi-333" "sorr" "SorMaker" "XINIT:$script %ROM%" "./SorMaker.dat"
     [[ "$md_mode" == "remove" ]] && return
 
     #create buffer script for launch
-    local script="$md_inst/$md_id.sh"
+
     cat > "$script" << _EOF_
 #!/bin/bash
 pushd "$romdir/ports/$md_id"
@@ -40,7 +43,6 @@ _EOF_
 
     chmod +x "$script"
     mkRomDir "ports/$md_id"
-    local config="$romdir/ports/$md_id/mod/system.txt"
     if [[ -f "$config" ]]; then
         # set custom "system" for 5.1 (allows proper "exit" from game menu)
         sed -i 's/system = PC/system = PSP/' "$config"

--- a/scriptmodules/ports/sorr.sh
+++ b/scriptmodules/ports/sorr.sh
@@ -25,6 +25,10 @@ function install_bin_sorr() {
 }
 
 function configure_sorr() {
+    addPort "bgdi-333" "sorr" "Streets of Rage Remake" "XINIT:$script %ROM%" "./SorR.dat"
+    [[ -f "$romdir/ports/$md_id/SorMaker.dat" || "$md_mode" == "remove" ]] && addPort "bgdi-333" "sorr" "SorMaker" "XINIT:$script %ROM%" "./SorMaker.dat"
+    [[ "$md_mode" == "remove" ]] && return
+
     #create buffer script for launch
     local script="$md_inst/$md_id.sh"
     cat > "$script" << _EOF_
@@ -35,10 +39,6 @@ popd
 _EOF_
 
     chmod +x "$script"
-    addPort "bgdi-333" "sorr" "Streets of Rage Remake" "XINIT:$script %ROM%" "./SorR.dat"
-    [[ -f "$romdir/ports/$md_id/SorMaker.dat" || "$md_mode" == "remove" ]] && addPort "bgdi-333" "sorr" "SorMaker" "XINIT:$script %ROM%" "./SorMaker.dat"
-    [[ "$md_mode" == "remove" ]] && return
-
     mkRomDir "ports/$md_id"
     local config="$romdir/ports/$md_id/mod/system.txt"
     if [[ -f "$config" ]]; then


### PR DESCRIPTION
This should actually be left root-owned since it's in `$md_inst` (`/opt/retropie/ports/...`; all of `/opt/retropie` is root except `configs`.)