### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto


### PR DESCRIPTION
I'm not sure if this works like I think it does...I think I'm reading that it will force Unix-style line-endings to be used when text files are added to the repo? (Recent fuse.sh and vice.sh files had DOS line-endings CR/LF instead of just LF.) If this doesn't work it may also require something like:

    * text eol=lf

Also not sure if or how it affects existing files. Vice and fuse may still need fixed manually.