### PR TITLE
update-extras.sh: pushd into script dir before update

### DIFF
--- a/update-extras.sh
+++ b/update-extras.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 scriptdir="$(dirname "$0")"
 
-cd "$scriptdir"
+pushd "$scriptdir"
 git pull origin
 ./install-extras.sh
+popd

--- a/update-extras.sh
+++ b/update-extras.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+scriptdir="$(dirname "$0")"
 
+cd "$scriptdir"
 git pull origin
 ./install-extras.sh


### PR DESCRIPTION
We don't want to update the wrong repo if script is called from another loc.