### PR TITLE
New headers for all scriptmodules

### DIFF
--- a/scriptmodules/emulators/fuse-1.6.sh
+++ b/scriptmodules/emulators/fuse-1.6.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="fuse-1.6"

--- a/scriptmodules/emulators/gearboy.sh
+++ b/scriptmodules/emulators/gearboy.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="gearboy"

--- a/scriptmodules/emulators/kat5200.sh
+++ b/scriptmodules/emulators/kat5200.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="kat5200"

--- a/scriptmodules/emulators/mpv.sh
+++ b/scriptmodules/emulators/mpv.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="mpv"

--- a/scriptmodules/emulators/openbor.sh
+++ b/scriptmodules/emulators/openbor.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="openbor-v6510"

--- a/scriptmodules/emulators/pico8.sh
+++ b/scriptmodules/emulators/pico8.sh
@@ -1,13 +1,14 @@
 
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="pico8"

--- a/scriptmodules/emulators/pokemini.sh
+++ b/scriptmodules/emulators/pokemini.sh
@@ -1,13 +1,14 @@
 
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="pokemini"

--- a/scriptmodules/emulators/ppsspp-latest.sh
+++ b/scriptmodules/emulators/ppsspp-latest.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="ppsspp-latest"

--- a/scriptmodules/emulators/supermodel.sh
+++ b/scriptmodules/emulators/supermodel.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="supermodel"

--- a/scriptmodules/emulators/vice-3.6.1.sh
+++ b/scriptmodules/emulators/vice-3.6.1.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="vice-3.6.1"

--- a/scriptmodules/libretrocores/lr-2048.sh
+++ b/scriptmodules/libretrocores/lr-2048.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-2048"

--- a/scriptmodules/libretrocores/lr-beetle-pce.sh
+++ b/scriptmodules/libretrocores/lr-beetle-pce.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-beetle-pce"

--- a/scriptmodules/libretrocores/lr-bk.sh
+++ b/scriptmodules/libretrocores/lr-bk.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-bk"

--- a/scriptmodules/libretrocores/lr-blastem.sh
+++ b/scriptmodules/libretrocores/lr-blastem.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-blastem"

--- a/scriptmodules/libretrocores/lr-boom3.sh
+++ b/scriptmodules/libretrocores/lr-boom3.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-boom3"

--- a/scriptmodules/libretrocores/lr-canary.sh
+++ b/scriptmodules/libretrocores/lr-canary.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-canary"

--- a/scriptmodules/libretrocores/lr-cannonball.sh
+++ b/scriptmodules/libretrocores/lr-cannonball.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-cannonball"

--- a/scriptmodules/libretrocores/lr-chailove.sh
+++ b/scriptmodules/libretrocores/lr-chailove.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-chailove"

--- a/scriptmodules/libretrocores/lr-citra.sh
+++ b/scriptmodules/libretrocores/lr-citra.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-citra"

--- a/scriptmodules/libretrocores/lr-craft.sh
+++ b/scriptmodules/libretrocores/lr-craft.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-craft"

--- a/scriptmodules/libretrocores/lr-crocods.sh
+++ b/scriptmodules/libretrocores/lr-crocods.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-crocods"

--- a/scriptmodules/libretrocores/lr-daphne.sh
+++ b/scriptmodules/libretrocores/lr-daphne.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-daphne"

--- a/scriptmodules/libretrocores/lr-duckstation.sh
+++ b/scriptmodules/libretrocores/lr-duckstation.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-duckstation"

--- a/scriptmodules/libretrocores/lr-easyrpg.sh
+++ b/scriptmodules/libretrocores/lr-easyrpg.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-easyrpg"

--- a/scriptmodules/libretrocores/lr-ecwolf.sh
+++ b/scriptmodules/libretrocores/lr-ecwolf.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-ecwolf"

--- a/scriptmodules/libretrocores/lr-fceumm-mod.sh
+++ b/scriptmodules/libretrocores/lr-fceumm-mod.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-fceumm-mod"

--- a/scriptmodules/libretrocores/lr-freej2me.sh
+++ b/scriptmodules/libretrocores/lr-freej2me.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-freej2me"

--- a/scriptmodules/libretrocores/lr-gearboy.sh
+++ b/scriptmodules/libretrocores/lr-gearboy.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-gearboy"

--- a/scriptmodules/libretrocores/lr-gearcoleco.sh
+++ b/scriptmodules/libretrocores/lr-gearcoleco.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-gearcoleco"

--- a/scriptmodules/libretrocores/lr-lutro.sh
+++ b/scriptmodules/libretrocores/lr-lutro.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-lutro"

--- a/scriptmodules/libretrocores/lr-mame2003_midway.sh
+++ b/scriptmodules/libretrocores/lr-mame2003_midway.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-mame2003_midway"

--- a/scriptmodules/libretrocores/lr-melonds.sh
+++ b/scriptmodules/libretrocores/lr-melonds.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-melonds"

--- a/scriptmodules/libretrocores/lr-mesen-s.sh
+++ b/scriptmodules/libretrocores/lr-mesen-s.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-mesen-s"

--- a/scriptmodules/libretrocores/lr-mess-jaguar.sh
+++ b/scriptmodules/libretrocores/lr-mess-jaguar.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-mess-jaguar"

--- a/scriptmodules/libretrocores/lr-minivmac.sh
+++ b/scriptmodules/libretrocores/lr-minivmac.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-minivmac"

--- a/scriptmodules/libretrocores/lr-mu.sh
+++ b/scriptmodules/libretrocores/lr-mu.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-mu"

--- a/scriptmodules/libretrocores/lr-oberon.sh
+++ b/scriptmodules/libretrocores/lr-oberon.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-oberon"

--- a/scriptmodules/libretrocores/lr-openlara.sh
+++ b/scriptmodules/libretrocores/lr-openlara.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-openlara"

--- a/scriptmodules/libretrocores/lr-play.sh
+++ b/scriptmodules/libretrocores/lr-play.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-play"

--- a/scriptmodules/libretrocores/lr-pocketcdg.sh
+++ b/scriptmodules/libretrocores/lr-pocketcdg.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-pocketcdg"

--- a/scriptmodules/libretrocores/lr-potator.sh
+++ b/scriptmodules/libretrocores/lr-potator.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-potator"

--- a/scriptmodules/libretrocores/lr-ppsspp-latest.sh
+++ b/scriptmodules/libretrocores/lr-ppsspp-latest.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-ppsspp-latest"

--- a/scriptmodules/libretrocores/lr-prboom-system.sh
+++ b/scriptmodules/libretrocores/lr-prboom-system.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-prboom-system"

--- a/scriptmodules/libretrocores/lr-race.sh
+++ b/scriptmodules/libretrocores/lr-race.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-race"

--- a/scriptmodules/libretrocores/lr-reminiscence.sh
+++ b/scriptmodules/libretrocores/lr-reminiscence.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-reminiscence"

--- a/scriptmodules/libretrocores/lr-sameboy.sh
+++ b/scriptmodules/libretrocores/lr-sameboy.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-sameboy"

--- a/scriptmodules/libretrocores/lr-simcoupe.sh
+++ b/scriptmodules/libretrocores/lr-simcoupe.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-simcoupe"

--- a/scriptmodules/libretrocores/lr-thepowdertoy.sh
+++ b/scriptmodules/libretrocores/lr-thepowdertoy.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-thepowdertoy"

--- a/scriptmodules/libretrocores/lr-uzem.sh
+++ b/scriptmodules/libretrocores/lr-uzem.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-uzem"

--- a/scriptmodules/libretrocores/lr-vemulator.sh
+++ b/scriptmodules/libretrocores/lr-vemulator.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-vemulator"

--- a/scriptmodules/libretrocores/lr-vitaquake2.sh
+++ b/scriptmodules/libretrocores/lr-vitaquake2.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-vitaquake2"

--- a/scriptmodules/libretrocores/lr-vitaquake3.sh
+++ b/scriptmodules/libretrocores/lr-vitaquake3.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-vitaquake3"

--- a/scriptmodules/libretrocores/lr-yabasanshiro.sh
+++ b/scriptmodules/libretrocores/lr-yabasanshiro.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lr-yabasanshiro"

--- a/scriptmodules/ports/abuse.sh
+++ b/scriptmodules/ports/abuse.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="abuse"

--- a/scriptmodules/ports/audacity.sh
+++ b/scriptmodules/ports/audacity.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="audacity"

--- a/scriptmodules/ports/augustus.sh
+++ b/scriptmodules/ports/augustus.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="augustus"

--- a/scriptmodules/ports/barrage.sh
+++ b/scriptmodules/ports/barrage.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="barrage"

--- a/scriptmodules/ports/bermudasyndrome.sh
+++ b/scriptmodules/ports/bermudasyndrome.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="bermudasyndrome"

--- a/scriptmodules/ports/bloboats.sh
+++ b/scriptmodules/ports/bloboats.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
- 
-# This file is part of The RetroPie Project
+
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
- 
+
 rp_module_id="bloboats"
 rp_module_desc="Bloboats"
 rp_module_section="exp"

--- a/scriptmodules/ports/breaker.sh
+++ b/scriptmodules/ports/breaker.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="breaker"

--- a/scriptmodules/ports/bstone.sh
+++ b/scriptmodules/ports/bstone.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="bstone"

--- a/scriptmodules/ports/burgerspace.sh
+++ b/scriptmodules/ports/burgerspace.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="burgerspace"

--- a/scriptmodules/ports/chocolate-doom-system.sh
+++ b/scriptmodules/ports/chocolate-doom-system.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="chocolate-doom-system"

--- a/scriptmodules/ports/chocolate-doom.sh
+++ b/scriptmodules/ports/chocolate-doom.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="chocolate-doom"

--- a/scriptmodules/ports/chopper258.sh
+++ b/scriptmodules/ports/chopper258.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="chopper258"

--- a/scriptmodules/ports/chromium.sh
+++ b/scriptmodules/ports/chromium.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="chromium"

--- a/scriptmodules/ports/corsixth.sh
+++ b/scriptmodules/ports/corsixth.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="corsixth"

--- a/scriptmodules/ports/crack-attack.sh
+++ b/scriptmodules/ports/crack-attack.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
- 
-# This file is part of The RetroPie Project
+
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
- 
+
 rp_module_id="crack-attack"
 rp_module_desc="Crack-Attack - Tetris Attack clone"
 rp_module_licence="GPL2 http://cvs.savannah.nongnu.org/viewvc/*checkout*/crack-attack/crack-attack/COPYING?revision=1.2"

--- a/scriptmodules/ports/crispy-doom-system.sh
+++ b/scriptmodules/ports/crispy-doom-system.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="crispy-doom-system"

--- a/scriptmodules/ports/crispy-doom.sh
+++ b/scriptmodules/ports/crispy-doom.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="crispy-doom"

--- a/scriptmodules/ports/deadbeef.sh
+++ b/scriptmodules/ports/deadbeef.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="deadbeef"

--- a/scriptmodules/ports/devilutionx.sh
+++ b/scriptmodules/ports/devilutionx.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="devilutionx"

--- a/scriptmodules/ports/dhewm3.sh
+++ b/scriptmodules/ports/dhewm3.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="dhewm3"

--- a/scriptmodules/ports/easyrpg-player.sh
+++ b/scriptmodules/ports/easyrpg-player.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="easyrpg-player"

--- a/scriptmodules/ports/ecwolf.sh
+++ b/scriptmodules/ports/ecwolf.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="ecwolf"

--- a/scriptmodules/ports/epiphany-browser.sh
+++ b/scriptmodules/ports/epiphany-browser.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="epiphany"

--- a/scriptmodules/ports/filezilla.sh
+++ b/scriptmodules/ports/filezilla.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="filezilla"

--- a/scriptmodules/ports/firefox-esr.sh
+++ b/scriptmodules/ports/firefox-esr.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="firefox-esr"

--- a/scriptmodules/ports/fofix.sh
+++ b/scriptmodules/ports/fofix.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
  
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
  
 rp_module_id="fofix"

--- a/scriptmodules/ports/freeciv.sh
+++ b/scriptmodules/ports/freeciv.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="freeciv"

--- a/scriptmodules/ports/freedink.sh
+++ b/scriptmodules/ports/freedink.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="freedink"

--- a/scriptmodules/ports/freesynd.sh
+++ b/scriptmodules/ports/freesynd.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="freesynd"

--- a/scriptmodules/ports/funnyboat.sh
+++ b/scriptmodules/ports/funnyboat.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="funnyboat"

--- a/scriptmodules/ports/ganbare.sh
+++ b/scriptmodules/ports/ganbare.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="ganbare"

--- a/scriptmodules/ports/gmloader.sh
+++ b/scriptmodules/ports/gmloader.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="gmloader"

--- a/scriptmodules/ports/gnukem.sh
+++ b/scriptmodules/ports/gnukem.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="gnukem"

--- a/scriptmodules/ports/gtkboard.sh
+++ b/scriptmodules/ports/gtkboard.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="gtkboard"

--- a/scriptmodules/ports/hcl.sh
+++ b/scriptmodules/ports/hcl.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
+#
 # Adapted from ZeroJay's RetroPie-Extra
 # https://github.com/zerojay/RetroPie-Extra
 

--- a/scriptmodules/ports/heboris.sh
+++ b/scriptmodules/ports/heboris.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
+#
 # This file is part of The RetroPie Project
 # 
 # The RetroPie Project is the legal property of its developers, whose names are

--- a/scriptmodules/ports/hexen2.sh
+++ b/scriptmodules/ports/hexen2.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
+#
 # This file is part of The RetroPie Project
 #
 # The RetroPie Project is the legal property of its developers, whose names are

--- a/scriptmodules/ports/hurrican.sh
+++ b/scriptmodules/ports/hurrican.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
+#
 # This file is part of The RetroPie Project
 #
 # The RetroPie Project is the legal property of its developers, whose names are

--- a/scriptmodules/ports/jfsw.sh
+++ b/scriptmodules/ports/jfsw.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="jfsw"

--- a/scriptmodules/ports/julius.sh
+++ b/scriptmodules/ports/julius.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="julius"

--- a/scriptmodules/ports/kaiten-patissier-ura.sh
+++ b/scriptmodules/ports/kaiten-patissier-ura.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="kaiten-patissier-ura"

--- a/scriptmodules/ports/kaiten-patissier.sh
+++ b/scriptmodules/ports/kaiten-patissier.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="kaiten-patissier"

--- a/scriptmodules/ports/kodi-extra.sh
+++ b/scriptmodules/ports/kodi-extra.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="kodi-extra"

--- a/scriptmodules/ports/kraptor.sh
+++ b/scriptmodules/ports/kraptor.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="kraptor"

--- a/scriptmodules/ports/kweb.sh
+++ b/scriptmodules/ports/kweb.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="kweb"

--- a/scriptmodules/ports/lbreakout2.sh
+++ b/scriptmodules/ports/lbreakout2.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lbreakout2"

--- a/scriptmodules/ports/lgeneral.sh
+++ b/scriptmodules/ports/lgeneral.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lgeneral"

--- a/scriptmodules/ports/librecad.sh
+++ b/scriptmodules/ports/librecad.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="librecad"

--- a/scriptmodules/ports/libreoffice.sh
+++ b/scriptmodules/ports/libreoffice.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="libreoffice"

--- a/scriptmodules/ports/lmarbles.sh
+++ b/scriptmodules/ports/lmarbles.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lmarbles"

--- a/scriptmodules/ports/ltris.sh
+++ b/scriptmodules/ports/ltris.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="ltris"

--- a/scriptmodules/ports/lutris.sh
+++ b/scriptmodules/ports/lutris.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="lutris"

--- a/scriptmodules/ports/maelstrom.sh
+++ b/scriptmodules/ports/maelstrom.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="maelstrom"

--- a/scriptmodules/ports/manaplus.sh
+++ b/scriptmodules/ports/manaplus.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="manaplus"

--- a/scriptmodules/ports/meritous.sh
+++ b/scriptmodules/ports/meritous.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="meritous"

--- a/scriptmodules/ports/mixx.sh
+++ b/scriptmodules/ports/mixx.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="mixxx"

--- a/scriptmodules/ports/mypaint.sh
+++ b/scriptmodules/ports/mypaint.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="mypaint"

--- a/scriptmodules/ports/nkaruga.sh
+++ b/scriptmodules/ports/nkaruga.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="nkaruga"

--- a/scriptmodules/ports/nxengine-evo.sh
+++ b/scriptmodules/ports/nxengine-evo.sh
@@ -1,15 +1,14 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
-#All work done by s1eve-mcdichae1 not ExarKunIV
-
 
 rp_module_id="nxengine-evo"
 rp_module_desc="Cave Story engine clone - NXEngine-Evo"

--- a/scriptmodules/ports/omxplayer.sh
+++ b/scriptmodules/ports/omxplayer.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
-# This file is part of The RetroPie Project
+
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
+
 rp_module_id="omxplayer"
 rp_module_desc="omxplayer - Video Player"
 rp_module_help="Put your videos into $"

--- a/scriptmodules/ports/opendune.sh
+++ b/scriptmodules/ports/opendune.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="opendune"

--- a/scriptmodules/ports/openjazz.sh
+++ b/scriptmodules/ports/openjazz.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="openjazz"

--- a/scriptmodules/ports/openjk_ja.sh
+++ b/scriptmodules/ports/openjk_ja.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="openjk_ja"

--- a/scriptmodules/ports/openjk_jo.sh
+++ b/scriptmodules/ports/openjk_jo.sh
@@ -1,13 +1,13 @@
-
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="openjk_jo"

--- a/scriptmodules/ports/openmw.sh
+++ b/scriptmodules/ports/openmw.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="openmw"

--- a/scriptmodules/ports/openmwdriver.sh
+++ b/scriptmodules/ports/openmwdriver.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="openmwdriver"

--- a/scriptmodules/ports/openra.sh
+++ b/scriptmodules/ports/openra.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="openra"

--- a/scriptmodules/ports/openrct2.sh
+++ b/scriptmodules/ports/openrct2.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="openrct2"

--- a/scriptmodules/ports/openxcom.sh
+++ b/scriptmodules/ports/openxcom.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="openxcom"

--- a/scriptmodules/ports/piegalaxy.sh
+++ b/scriptmodules/ports/piegalaxy.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="piegalaxy"

--- a/scriptmodules/ports/pingus.sh
+++ b/scriptmodules/ports/pingus.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="pingus"

--- a/scriptmodules/ports/pokerth.sh
+++ b/scriptmodules/ports/pokerth.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="pokerth"

--- a/scriptmodules/ports/prboom-plus.sh
+++ b/scriptmodules/ports/prboom-plus.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="prboom-plus"

--- a/scriptmodules/ports/prototype.sh
+++ b/scriptmodules/ports/prototype.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="prototype"

--- a/scriptmodules/ports/putty.sh
+++ b/scriptmodules/ports/putty.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="putty"

--- a/scriptmodules/ports/pydance.sh
+++ b/scriptmodules/ports/pydance.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="pydance"

--- a/scriptmodules/ports/quakespasm.sh
+++ b/scriptmodules/ports/quakespasm.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="quakespasm"

--- a/scriptmodules/ports/rawgl.sh
+++ b/scriptmodules/ports/rawgl.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="rawgl"

--- a/scriptmodules/ports/refkeen.sh
+++ b/scriptmodules/ports/refkeen.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="refkeen"

--- a/scriptmodules/ports/relive.sh
+++ b/scriptmodules/ports/relive.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="relive"

--- a/scriptmodules/ports/reminiscence.sh
+++ b/scriptmodules/ports/reminiscence.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="reminiscence"

--- a/scriptmodules/ports/rickyd.sh
+++ b/scriptmodules/ports/rickyd.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="rickyd"

--- a/scriptmodules/ports/rigelengine.sh
+++ b/scriptmodules/ports/rigelengine.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="rigelengine"

--- a/scriptmodules/ports/rocksndiamonds.sh
+++ b/scriptmodules/ports/rocksndiamonds.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="rocksndiamonds"

--- a/scriptmodules/ports/rott-darkwar.sh
+++ b/scriptmodules/ports/rott-darkwar.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="rott-darkwar"

--- a/scriptmodules/ports/rott-huntbgin.sh
+++ b/scriptmodules/ports/rott-huntbgin.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="rott-huntbgin"

--- a/scriptmodules/ports/rtcw.sh
+++ b/scriptmodules/ports/rtcw.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="rtcw"

--- a/scriptmodules/ports/sdl-bomber.sh
+++ b/scriptmodules/ports/sdl-bomber.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="sdl-bomber"

--- a/scriptmodules/ports/seahorse.sh
+++ b/scriptmodules/ports/seahorse.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="seahorse"

--- a/scriptmodules/ports/shiromino.sh
+++ b/scriptmodules/ports/shiromino.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="shiromino"

--- a/scriptmodules/ports/sm64ex.sh
+++ b/scriptmodules/ports/sm64ex.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="sm64ex"

--- a/scriptmodules/ports/sorr.sh
+++ b/scriptmodules/ports/sorr.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="sorr"

--- a/scriptmodules/ports/supertuxkart.sh
+++ b/scriptmodules/ports/supertuxkart.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="supertuxkart"

--- a/scriptmodules/ports/texmaster2009.sh
+++ b/scriptmodules/ports/texmaster2009.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="texmaster2009"

--- a/scriptmodules/ports/thunderbird.sh
+++ b/scriptmodules/ports/thunderbird.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="thunderbird"

--- a/scriptmodules/ports/tinyfugue.sh
+++ b/scriptmodules/ports/tinyfugue.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="tinyfugue"

--- a/scriptmodules/ports/ulmos-adventure.sh
+++ b/scriptmodules/ports/ulmos-adventure.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="ulmos-adventure"

--- a/scriptmodules/ports/vgmplay.sh
+++ b/scriptmodules/ports/vgmplay.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="vgmplay"

--- a/scriptmodules/ports/videolan.sh
+++ b/scriptmodules/ports/videolan.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="vlc"

--- a/scriptmodules/ports/vorton.sh
+++ b/scriptmodules/ports/vorton.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="vorton"

--- a/scriptmodules/ports/warmux.sh
+++ b/scriptmodules/ports/warmux.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
  
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
  
 rp_module_id="warmux"

--- a/scriptmodules/ports/weechat.sh
+++ b/scriptmodules/ports/weechat.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="weechat"

--- a/scriptmodules/ports/wizznic.sh
+++ b/scriptmodules/ports/wizznic.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="wizznic"

--- a/scriptmodules/ports/xash3d-fwgs.sh
+++ b/scriptmodules/ports/xash3d-fwgs.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="xash3d-fwgs"

--- a/scriptmodules/ports/zeldansq.sh
+++ b/scriptmodules/ports/zeldansq.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="zeldansq"

--- a/scriptmodules/ports/zeldapicross.sh
+++ b/scriptmodules/ports/zeldapicross.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
-# 
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
-# 
-# See the LICENSE.md file at the top-level directory of this distribution and 
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="zeldapicross"

--- a/scriptmodules/supplementary/bezelproject.sh
+++ b/scriptmodules/supplementary/bezelproject.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
-##############
+
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
+#
 
 rp_module_id="bezelproject"
 rp_module_desc="Easily set up the Bezel Project"

--- a/scriptmodules/supplementary/bgm123.sh
+++ b/scriptmodules/supplementary/bgm123.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="bgm123"

--- a/scriptmodules/supplementary/fun-facts-splashscreens.sh
+++ b/scriptmodules/supplementary/fun-facts-splashscreens.sh
@@ -1,5 +1,15 @@
 #!/usr/bin/env bash
 
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
+#
+
 rp_module_id="fun-facts-splashscreens"
 rp_module_desc="A tool for RetroPie to generate splashscreens with random video game related Fun Facts!."
 rp_module_help="Basics:"

--- a/scriptmodules/supplementary/gparted.sh
+++ b/scriptmodules/supplementary/gparted.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="gparted"

--- a/scriptmodules/supplementary/joystick-selection.sh
+++ b/scriptmodules/supplementary/joystick-selection.sh
@@ -1,5 +1,15 @@
 #!/usr/bin/env bash
 
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
+#
+
 rp_module_id="joystick-selection"
 rp_module_desc="Set controllers for RetroArch players 1-4 (global or system specific)."
 rp_module_help="Follow the instructions on the dialogs to configure which joystick to use for RetroArch players 1-4 (global or system specific)."

--- a/scriptmodules/supplementary/mame-tools.sh
+++ b/scriptmodules/supplementary/mame-tools.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="mame-tools"

--- a/scriptmodules/supplementary/screenshot.sh
+++ b/scriptmodules/supplementary/screenshot.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-# This file is part of The RetroPie Project
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
 #
-# The RetroPie Project is the legal property of its developers, whose names are
-# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
 #
-# See the LICENSE.md file at the top-level directory of this distribution and
-# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+# See the LICENSE file distributed with this source and at
+# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
 #
 
 rp_module_id="screenshot"


### PR DESCRIPTION
Most of the old ones said "This file is part of The RetroPie Project", which isn't true. Only a few didn't say anything at all.

New headers say "This file is part of RetroPie-Extra, a supplement to RetroPie."

```
# This file is part of RetroPie-Extra, a supplement to RetroPie.
# For more information, please visit:
#
# https://github.com/RetroPie/RetroPie-Setup
# https://github.com/Exarkuniv/RetroPie-Extra
#
# See the LICENSE file distributed with this source and at
# https://github.com/Exarkuniv/RetroPie-Extra/blob/master/LICENSE
#
```