### PR TITLE
bgm123 - better fix for killing player while stopped

### DIFF
--- a/scriptmodules/supplementary/bgm123.sh
+++ b/scriptmodules/supplementary/bgm123.sh
@@ -150,13 +150,9 @@ function toggle_bgm123() {
     )
     $(_get_vars_bgm123 "${vars[@]}")
 
-    # backup files and attempt to remove any existing bgm config
+    # attempt to remove any existing bgm config
     for file in "$autostart" "$bashrc" "$onstart" "$onend"; do
-        if [[ -f "$file" ]]; then
-            cp -f "$file" "$file.bak"
-            chown $user:$user "$file.bak"
-            sed -i '/#bgm/d' "$file"
-        fi
+        [[ -f "$file" ]] && sed -i '/#bgm/d' "$file"
     done
 
     # enable with toggle "on" or "enable(d)"

--- a/scriptmodules/supplementary/bgm123/bgm_fade.sh
+++ b/scriptmodules/supplementary/bgm123/bgm_fade.sh
@@ -26,7 +26,7 @@ readonly MUSIC_PLAYER="$music_player"
 # command for amixer (use -M for mapped volume)
 # don't quote $MIXER in commands when -M (or any params) are used
 MIXER="amixer"
-[[ "$mapped_volume" -eq 1 ]] && MIXER="amixer -M"
+[[ "$mapped_volume" == "enabled" ]] && MIXER="amixer -M"
 readonly MIXER
 
 # get mixer volume
@@ -66,7 +66,7 @@ if [[ "${PLAYER_STATUS,,}" == *s* || "${PLAYER_STATUS,,}" == *r* ]]; then
     fade_volume="$MIXER_VOLUME"
     volume_step="$[$MIXER_VOLUME /20]"
     until [[ "$fade_volume" -le 10 ]]; do
-        [[ "$mapped_volume" -eq 1 ]] || setStep
+        [[ "$mapped_volume" == "enabled" ]] || setStep
         fade_volume="$[$fade_volume -$volume_step]"
         $MIXER -q set "$MIXER_CHANNEL" "${fade_volume}%"
         sleep 0.1
@@ -85,7 +85,7 @@ elif [[ "${PLAYER_STATUS,,}" == *t* ]]; then
     fade_volume="10"
     volume_step="$[$MIXER_VOLUME /20]"
     until [[ "$fade_volume" -ge "$MIXER_VOLUME" ]]; do
-        [[ "$mapped_volume" -eq 1 ]] || setStep
+        [[ "$mapped_volume" == "enabled" ]] || setStep
         fade_volume="$[$fade_volume +$volume_step]"
         $MIXER -q set "$MIXER_CHANNEL" "${fade_volume}%"
         sleep 0.2

--- a/scriptmodules/supplementary/bgm123/bgm_stop.sh
+++ b/scriptmodules/supplementary/bgm123/bgm_stop.sh
@@ -5,4 +5,4 @@
 source #autoconf
 
 vcgencmd force_audio hdmi 0 >/dev/null && sleep 0.1
-pkill "$music_player"
+pkill -9 "$music_player"

--- a/scriptmodules/supplementary/bgm123/bgm_stop.sh
+++ b/scriptmodules/supplementary/bgm123/bgm_stop.sh
@@ -5,4 +5,5 @@
 source #autoconf
 
 vcgencmd force_audio hdmi 0 >/dev/null && sleep 0.1
-pkill -9 "$music_player"
+pkill "$music_player"
+[[ "$(ps -ostate= -C $music_player)" == "T" ]] && pkill -CONT "$music_player"


### PR DESCRIPTION
SIGKILL was messy and introduced additional unwanted console text.

SIGTERM is received by the stopped process, but it is unable to terminate WHILE stopped. Terminates immediately upon SIGCONT.

Solution: after SIGTERM, check if stopped process exists and send SIGCONT to wake it up and terminate it.

Also improved handling of "global" variables. Now using an associative array instead of a `case` list; all requested vars now assigned with a single call to `_get_vars` in each function.