### PR TITLE
heboris.sh - fixup 'configure' function

### DIFF
--- a/scriptmodules/ports/heboris.sh
+++ b/scriptmodules/ports/heboris.sh
@@ -45,10 +45,13 @@ function configure_heboris() {
     local script="$md_inst/$md_id.sh"
     local conf
 
-    for conf in config replay res heboris.ini; do
+    for conf in config replay res; do
         chown -R $user:$user "$md_inst/$conf"
-        moveConfigDir "$md_inst/$conf" "md_conf_root/$md_id"
+        moveConfigDir "$md_inst/$conf" "$md_conf_root/$md_id/$conf"
     done
+
+    chown $user:$user "$md_inst/heboris.ini"
+    moveConfigFile "$md_inst/heboris.ini" "$md_conf_root/$md_id/heboris.ini"
 
     #create buffer script for launch
     cat > "$script" << _EOF_


### PR DESCRIPTION
I forgot a $.

I tried to use 'moveConfigDir' on a file.

I neglected that 'moveConfigDir' and 'moveConfigFile' do not work like an actual 'mv' -- they do need the actual target filename, and not just the destination dir.