### PR TITLE
Openjk

### DIFF
--- a/scriptmodules/ports/openjk_ja.sh
+++ b/scriptmodules/ports/openjk_ja.sh
@@ -24,8 +24,7 @@ function _arch_openjk_ja() {
 }
 
 function depends_openjk_ja() {
-    getDepends build-essential cmake libjpeg-dev libpng-dev zlib1g-dev libsdl2-dev
-
+    getDepends cmake libjpeg-dev libpng-dev zlib1g-dev libsdl2-dev
 }
 
 function sources_openjk_ja() {
@@ -66,29 +65,36 @@ function install_openjk_ja() {
     )
 }
 
-function game_data_openjk_ja() {
-    for lib in ui cgame jagame jampgame
-    do
-        cp "${md_inst}/${lib}$(_arch_openjk_ja).so" "${romdir}/ports/jediacademy/${lib}$(_arch_openjk_ja).so"
-    done
-}
-
 function configure_openjk_ja() {
-    local launcher_sp=("${md_inst}/openjk_sp.$(_arch_openjk_ja) +set fs_basepath /home/pi/RetroPie/roms/ports/jediacademy")
-    local launcher_mp=("${md_inst}/openjk.$(_arch_openjk_ja) +set fs_basepath /home/pi/RetroPie/roms/ports/jediacademy")
-	isPlatform "mesa" && launcher_sp+=("+set cl_renderer opengl1")
-    	isPlatform "kms" && launcher_sp+=("+set r_mode -1" "+set r_customwidth %XRES%" "+set r_customheight %YRES%" "+set r_swapInterval 1")
-	isPlatform "mesa" && launcher_mp+=("+set cl_renderer opengl1")
-    	isPlatform "kms" && launcher_mp+=("+set r_mode -1" "+set r_customwidth %XRES%" "+set r_customheight %YRES%" "+set r_swapInterval 1")
+    local launcher_sp="${md_inst}/openjk_sp.$(_arch_openjk_ja)"
+    local launcher_mp="${md_inst}/openjk.$(_arch_openjk_ja)"
+    local params=("+set fs_basepath $md_inst")
+    isPlatform "mesa" && params+=("+set cl_renderer opengl1")
+    isPlatform "kms" && params+=("+set r_mode -1" "+set r_customwidth %XRES%" "+set r_customheight %YRES%" "+set r_swapInterval 1")
+    local script="$md_inst/launch-$md_id.sh"
 
-
-    addPort "${md_id}" "jediacademy_sp" "Star Wars - Jedi Knight - Jedi Academy (SP)" "${launcher_sp[*]}"
-    addPort "${md_id}" "jediacademy_mp" "Star Wars - Jedi Knight - Jedi Academy (MP)" "${launcher_mp[*]}"
+    addPort "${md_id}" "jediacademy" "Star Wars - Jedi Knight - Jedi Academy (SP)" "$script %ROM% ${params[*]}" "sp"
+    addPort "${md_id}" "jediacademy" "Star Wars - Jedi Knight - Jedi Academy (MP)" "$script %ROM% ${params[*]}" "mp"
 
     mkRomDir "ports/jediacademy"
 
     moveConfigDir "${md_inst}/base" "$romdir/ports/jediacademy"
     moveConfigDir "$home/.local/share/openjk" "${md_conf_root}/jediacademy/openjk"
 
-    [[ "$md_mode" == "install" ]] && game_data_openjk_ja
+    if [[ "$md_mode" == "install" ]]; then
+        cat > "$script" << _EOF_
+#!/bin/bash
+mode="\$1"
+shift
+
+case "\$mode" in
+    sp) launcher="$launcher_sp" ;;
+    mp) launcher="$launcher_mp" ;;
+esac
+
+[[ -n "\$launcher" ]] && "\$launcher" "\$@"
+_EOF_
+
+    chmod +x "$script"
+    fi
 }

--- a/scriptmodules/ports/openjk_ja.sh
+++ b/scriptmodules/ports/openjk_ja.sh
@@ -78,7 +78,7 @@ function configure_openjk_ja() {
     ln -snf "$romdir/ports/jediacademy" "$md_inst/base"
 
     # link required libs to game dir (required for multiplayer)
-    for lib in ui cgame; do
+    for lib in ui cgame jampgame; do
         ln -sf "$md_inst/$lib$(_arch_openjk_ja).so" "$romdir/ports/jediacademy/$lib$(_arch_openjk_ja).so"
         chown -h $user:$user "$romdir/ports/jediacademy/$lib$(_arch_openjk_ja).so"
     done

--- a/scriptmodules/ports/openjk_ja.sh
+++ b/scriptmodules/ports/openjk_ja.sh
@@ -39,15 +39,7 @@ function build_openjk_ja() {
     make
 
     md_ret_require=(
-        "$md_build/build/openjkded.$(_arch_openjk_ja)"
-        "$md_build/build/openjk_sp.$(_arch_openjk_ja)"
         "$md_build/build/openjk.$(_arch_openjk_ja)"
-        "$md_build/build/code/game/jagame$(_arch_openjk_ja).so"
-        "$md_build/build/code/rd-vanilla/rdsp-vanilla_$(_arch_openjk_ja).so"
-        "$md_build/build/codemp/game/jampgame$(_arch_openjk_ja).so"
-        "$md_build/build/codemp/cgame/cgame$(_arch_openjk_ja).so"
-        "$md_build/build/codemp/ui/ui$(_arch_openjk_ja).so"
-        "$md_build/build/codemp/rd-vanilla/rd-vanilla_$(_arch_openjk_ja).so"
     )
 }
 

--- a/scriptmodules/ports/openjk_ja.sh
+++ b/scriptmodules/ports/openjk_ja.sh
@@ -78,10 +78,10 @@ function configure_openjk_ja() {
 
     mkRomDir "ports/jediacademy"
 
-    moveConfigDir "$md_inst/base" "$romdir/ports/jediacademy"
     moveConfigDir "$home/.local/share/openjk" "$md_conf_root/jediacademy/openjk"
 
     if [[ "$md_mode" == "install" ]]; then
+        ln -snf "$romdir/ports/jediacademy" "$md_inst/base"
         cat > "$script" << _EOF_
 #!/bin/bash
 mode="\$1"

--- a/scriptmodules/ports/openjk_ja.sh
+++ b/scriptmodules/ports/openjk_ja.sh
@@ -60,7 +60,7 @@ function install_openjk_ja() {
 function configure_openjk_ja() {
     local launcher_sp="$md_inst/openjk_sp.$(_arch_openjk_ja)"
     local launcher_mp="$md_inst/openjk.$(_arch_openjk_ja)"
-    local params=("+set fs_basepath $md_inst")
+    local params=()
     isPlatform "mesa" && params+=("+set cl_renderer opengl1")
     isPlatform "kms" && params+=("+set r_mode -1" "+set r_customwidth %XRES%" "+set r_customheight %YRES%" "+set r_swapInterval 1")
     local script="$md_inst/launch-$md_id.sh"
@@ -72,9 +72,18 @@ function configure_openjk_ja() {
 
     moveConfigDir "$home/.local/share/openjk" "$md_conf_root/jediacademy/openjk"
 
-    if [[ "$md_mode" == "install" ]]; then
-        ln -snf "$romdir/ports/jediacademy" "$md_inst/base"
-        cat > "$script" << _EOF_
+    [[ "$md_mode" == "remove" ]] && return
+
+    # link game data to install dir
+    ln -snf "$romdir/ports/jediacademy" "$md_inst/base"
+
+    # link required libs to game dir (required for multiplayer)
+    for lib in ui cgame; do
+        ln -sf "$md_inst/$lib$(_arch_openjk_ja).so" "$romdir/ports/jediacademy/$lib$(_arch_openjk_ja).so"
+        chown -h $user:$user "$romdir/ports/jediacademy/$lib$(_arch_openjk_ja).so"
+    done
+
+    cat > "$script" << _EOF_
 #!/bin/bash
 mode="\$1"
 shift
@@ -88,5 +97,4 @@ esac
 _EOF_
 
     chmod +x "$script"
-    fi
 }

--- a/scriptmodules/ports/openjk_ja.sh
+++ b/scriptmodules/ports/openjk_ja.sh
@@ -66,20 +66,20 @@ function install_openjk_ja() {
 }
 
 function configure_openjk_ja() {
-    local launcher_sp="${md_inst}/openjk_sp.$(_arch_openjk_ja)"
-    local launcher_mp="${md_inst}/openjk.$(_arch_openjk_ja)"
+    local launcher_sp="$md_inst/openjk_sp.$(_arch_openjk_ja)"
+    local launcher_mp="$md_inst/openjk.$(_arch_openjk_ja)"
     local params=("+set fs_basepath $md_inst")
     isPlatform "mesa" && params+=("+set cl_renderer opengl1")
     isPlatform "kms" && params+=("+set r_mode -1" "+set r_customwidth %XRES%" "+set r_customheight %YRES%" "+set r_swapInterval 1")
     local script="$md_inst/launch-$md_id.sh"
 
-    addPort "${md_id}" "jediacademy" "Star Wars - Jedi Knight - Jedi Academy (SP)" "$script %ROM% ${params[*]}" "sp"
-    addPort "${md_id}" "jediacademy" "Star Wars - Jedi Knight - Jedi Academy (MP)" "$script %ROM% ${params[*]}" "mp"
+    addPort "$md_id" "jediacademy" "Star Wars - Jedi Knight - Jedi Academy (SP)" "$script %ROM% ${params[*]}" "sp"
+    addPort "$md_id" "jediacademy" "Star Wars - Jedi Knight - Jedi Academy (MP)" "$script %ROM% ${params[*]}" "mp"
 
     mkRomDir "ports/jediacademy"
 
-    moveConfigDir "${md_inst}/base" "$romdir/ports/jediacademy"
-    moveConfigDir "$home/.local/share/openjk" "${md_conf_root}/jediacademy/openjk"
+    moveConfigDir "$md_inst/base" "$romdir/ports/jediacademy"
+    moveConfigDir "$home/.local/share/openjk" "$md_conf_root/jediacademy/openjk"
 
     if [[ "$md_mode" == "install" ]]; then
         cat > "$script" << _EOF_

--- a/scriptmodules/ports/openjk_jo.sh
+++ b/scriptmodules/ports/openjk_jo.sh
@@ -67,7 +67,7 @@ function configure_openjk_jo() {
     mkRomDir "ports/jedioutcast"
 
     moveConfigDir "$md_inst/base" "$romdir/ports/jedioutcast"
-    moveConfigDir "$home/.local/share/openjo" "${md_conf_root}/jedioutcast/openjo"
+    moveConfigDir "$home/.local/share/openjo" "$md_conf_root/jedioutcast/openjo"
 
     if [[ "$md_mode" == "install" ]]; then
     cat > "$script" << _EOF_

--- a/scriptmodules/ports/openjk_jo.sh
+++ b/scriptmodules/ports/openjk_jo.sh
@@ -57,7 +57,7 @@ function install_openjk_jo() {
 
 function configure_openjk_jo() {
     local launcher_jo_sp="$md_inst/openjo_sp.$(_arch_openjk_jo)"
-    local params=("+set fs_basepath $md_inst" "+set com_jk2 1")
+    local params=("+set com_jk2 1")
     isPlatform "mesa" && params+=("+set cl_renderer opengl1")
     isPlatform "kms" && params+=("+set r_mode -1" "+set r_customwidth %XRES%" "+set r_customheight %YRES%" "+set r_swapInterval 1")
     local script="$md_inst/launch-$md_id.sh"
@@ -68,9 +68,13 @@ function configure_openjk_jo() {
 
     moveConfigDir "$home/.local/share/openjo" "$md_conf_root/jedioutcast/openjo"
 
-    if [[ "$md_mode" == "install" ]]; then
-        ln -snf "$romdir/ports/jedioutcast" "$md_inst/base"
-        cat > "$script" << _EOF_
+    [[ "$md_mode" == "remove" ]] && return
+
+    # link game data to install dir
+    ln -snf "$romdir/ports/jedioutcast" "$md_inst/base"
+
+    # dummy launch script to mirror openjk_ja and prep for future JO multiplayer
+    cat > "$script" << _EOF_
 #!/bin/bash
 mode="\$1"
 shift
@@ -83,5 +87,4 @@ esac
 _EOF_
 
     chmod +x "$script"
-    fi
 }

--- a/scriptmodules/ports/openjk_jo.sh
+++ b/scriptmodules/ports/openjk_jo.sh
@@ -66,11 +66,11 @@ function configure_openjk_jo() {
 
     mkRomDir "ports/jedioutcast"
 
-    moveConfigDir "$md_inst/base" "$romdir/ports/jedioutcast"
     moveConfigDir "$home/.local/share/openjo" "$md_conf_root/jedioutcast/openjo"
 
     if [[ "$md_mode" == "install" ]]; then
-    cat > "$script" << _EOF_
+        ln -snf "$romdir/ports/jedioutcast" "$md_inst/base"
+        cat > "$script" << _EOF_
 #!/bin/bash
 mode="\$1"
 shift

--- a/scriptmodules/ports/openjk_jo.sh
+++ b/scriptmodules/ports/openjk_jo.sh
@@ -13,7 +13,8 @@
 rp_module_id="openjk_jo"
 rp_module_desc="openjk_jo - OpenJK: Jedi Outcast (SP)"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/JACoders/OpenJK/master/LICENSE.txt"
-rp_module_help="Copy assets0.pk3  assets1.pk3  assets2.pk3  assets5.pk3 into $romdir/jedioutcast/base"
+rp_module_help="Copy assets0.pk3  assets1.pk3  assets2.pk3  assets5.pk3 into $romdir/jedioutcast"
+rp_module_repo="git https://github.com/JACoders/OpenJK.git"
 rp_module_section="exp"
 rp_module_flags=""
 
@@ -23,12 +24,11 @@ function _arch_openjk_jo() {
 }
 
 function depends_openjk_jo() {
-    getDepends build-essential cmake libjpeg-dev libpng-dev zlib1g-dev libsdl2-dev
-
+    getDepends cmake libjpeg-dev libpng-dev zlib1g-dev libsdl2-dev
 }
 
 function sources_openjk_jo() {
-    gitPullOrClone "$md_build" https://github.com/JACoders/OpenJK.git
+    gitPullOrClone
 }
 
 function build_openjk_jo() {
@@ -56,15 +56,32 @@ function install_openjk_jo() {
 }
 
 function configure_openjk_jo() {
-    local launcher_jo_sp=("$md_inst/openjo_sp.$(_arch_openjk_jo) +set fs_basepath /home/pi/RetroPie/roms/ports/jedioutcast +set com_jk2 1")
-    isPlatform "mesa" && launcher_jo_sp+=("+set cl_renderer opengl1")
-    isPlatform "kms" && launcher_jo_sp+=("+set r_mode -1" "+set r_customwidth %XRES%" "+set r_customheight %YRES%" "+set r_swapInterval 1")
+    local launcher_jo_sp="$md_inst/openjo_sp.$(_arch_openjk_jo)"
+    local params=("+set fs_basepath $md_inst" "+set com_jk2 1")
+    isPlatform "mesa" && params+=("+set cl_renderer opengl1")
+    isPlatform "kms" && params+=("+set r_mode -1" "+set r_customwidth %XRES%" "+set r_customheight %YRES%" "+set r_swapInterval 1")
+    local script="$md_inst/launch-$md_id.sh"
 
-    addPort "$md_id" "jedioutcast_sp" "Star Wars - Jedi Knight - Jedi Outcast (SP)" "${launcher_jo_sp[*]}"
+    addPort "$md_id" "jedioutcast" "Star Wars - Jedi Knight - Jedi Outcast (SP)" "$script %ROM% ${params[*]}" "sp"
 
     mkRomDir "ports/jedioutcast"
-    mkRomDir "ports/jedioutcast/base"
-    ln -sf "$md_inst/jospgame$(_arch_openjk_jo).so" "$romdir/ports/jedioutcast/base"
-    moveConfigDir "$home/.local/share/openjo" "${md_conf_root}/jedioutcast/openjo"
-}
 
+    moveConfigDir "$md_inst/base" "$romdir/ports/jedioutcast"
+    moveConfigDir "$home/.local/share/openjo" "${md_conf_root}/jedioutcast/openjo"
+
+    if [[ "$md_mode" == "install" ]]; then
+    cat > "$script" << _EOF_
+#!/bin/bash
+mode="\$1"
+shift
+
+case "\$mode" in
+    sp) launcher="$launcher_jo_sp" ;;
+esac
+
+[[ -n "\$launcher" ]] && "\$launcher" "\$@"
+_EOF_
+
+    chmod +x "$script"
+    fi
+}


### PR DESCRIPTION
I haven't tested JO or JAMP yet but this seems to work for JASP, at least.

Couple things going on here:

- Got rid of the separate SP/MP config dirs in JA

Did this by running them through a `launch-$md_id.sh` script that uses the %ROM% parameter to select which launcher to use, so it can use the same `emulators.cfg` command for both modes. (Did the same treatment for JO even though not strictly necessary since it only has SP; this sets it up if upstream should ever enable MP, we can include it with just a few lines to ret the files and set the command.)

- No more install files in roms dir

So this is what that linking of the **base** folder from **md_inst** to **romdir** was about.

What it *needs* is, a **base** folder with game files in it, to be in the same folder with the binary files. Then we point `+set fs_basepath` at (the parent folder of) that **base** folder.

Previously, this was accomplished by:

- Put a **base** folder in the game dir, and

- link the relevant binaries to the game dir, and

- point `fs_basepath` at the game dir.

Instead, this will:

- Put a **base** folder in the *install dir*, and

- make that a link *to* the game dir, and

- point `fs_basepath` at the install dir where the binaries and the (fake) **base** folder are.

This allows to place the game data files directly in **jediacademy** or **jedioutcast** romdir folders, without the need for a **base** folder or any install files in this area.

- Minor

use `$rp_module_repo` var 

removed hard-dep `build-essential`