### PR TITLE
gitattributes - don't convert .diff or .patch files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,6 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+# don't convert .diff or .patch files
+*.diff binary
+*.patch binary


### PR DESCRIPTION
Flag `*.diff` and `*.patch` files as binary so they aren't subject to text-normalization (normalized patches may fail when applied.)