### PR TITLE
Update ecwolf keyboard patch

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,6 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+# don't convert .diff or .patch files
+*.diff binary
+*.patch binary

--- a/scriptmodules/ports/ecwolf.sh
+++ b/scriptmodules/ports/ecwolf.sh
@@ -28,8 +28,8 @@ function sources_ecwolf() {
 
 function build_ecwolf() {
     cd "$md_build"
-    #wget -N -q https://raw.githubusercontent.com/tpo1990/ECWolf-RPI/master/ecwolf_keyboardpatch.diff
-    #applyPatch ecwolf_keyboardpatch.diff
+    # add Escape to controller bindable keys to access main menu
+    applyPatch "$md_data/01_keyboard_patch.diff"
     cmake . -DCMAKE_BUILD_TYPE=Release -DGPL=ON
     make
     md_ret_require="$md_build"

--- a/scriptmodules/ports/ecwolf/01_keyboard_patch.diff
+++ b/scriptmodules/ports/ecwolf/01_keyboard_patch.diff
@@ -1,0 +1,12 @@
+diff --git a/src/wl_play.cpp b/src/wl_play.cpp
+index 4420b06..932d764 100644
+--- a/src/wl_play.cpp
++++ b/src/wl_play.cpp
+@@ -101,6 +101,7 @@ ControlScheme controlScheme[] =
+ 	{ bt_automap,			"Automap",		-1,			-1,				-1, CS_AxisDigital, 0 },
+ 	{ bt_showstatusbar,		"Show Status",	-1,			sc_Tab,			-1,	CS_AxisDigital, 0 },
+ 	{ bt_pause,				"Pause",		-1,			sc_Pause,		-1, CS_AxisDigital, 0 },
++	{ bt_esc,			"Escape Game",		-1,			sc_Escape,		-1, CS_AxisDigital, 0 },
+ 
+ 	// End of List
+ 	{ bt_nobutton,			NULL, -1, -1, -1, CS_AxisDigital, 0 }


### PR DESCRIPTION
New repo-included keyboard patch to replace the old web-downloadable one. Adds Esc to controller-bindable keys for main menu access on some controllers.

Includes **gitattributes** fix from previous PR.