### PR TITLE
gnukem.sh - restore data repo and change repo branch(es)

### DIFF
--- a/scriptmodules/ports/gnukem.sh
+++ b/scriptmodules/ports/gnukem.sh
@@ -23,6 +23,7 @@ function depends_gnukem() {
 
 function sources_gnukem() {
     gitPullOrClone
+    gitPullOrClone "$md_build/data" https://github.com/davidjoffe/gnukem_data.git
 }
 
 function build_gnukem() {

--- a/scriptmodules/ports/gnukem.sh
+++ b/scriptmodules/ports/gnukem.sh
@@ -13,7 +13,7 @@
 rp_module_id="gnukem"
 rp_module_desc="Dave Gnukem - Duke Nukem 1 look-a-like"
 rp_module_licence="MIT https://github.com/davidjoffe/dave_gnukem/blob/master/MIT-LICENSE.txt"
-rp_module_repo="git https://github.com/davidjoffe/dave_gnukem.git"
+rp_module_repo="git https://github.com/davidjoffe/dave_gnukem.git main"
 rp_module_section="exp"
 rp_module_flags=""
 
@@ -23,7 +23,7 @@ function depends_gnukem() {
 
 function sources_gnukem() {
     gitPullOrClone
-    gitPullOrClone "$md_build/data" https://github.com/davidjoffe/gnukem_data.git
+    gitPullOrClone "$md_build/data" https://github.com/davidjoffe/gnukem_data.git main
 }
 
 function build_gnukem() {


### PR DESCRIPTION
Source and data repos now use "main" branch ID instead of "master."