### PR TITLE
Variable $rp_module_help is parsed before $md_id is available

### DIFF
--- a/scriptmodules/ports/bermudasyndrome.sh
+++ b/scriptmodules/ports/bermudasyndrome.sh
@@ -12,7 +12,7 @@
 
 rp_module_id="bermudasyndrome"
 rp_module_desc="Bermuda Syndrome - Open Source Engine"
-rp_module_help="Please copy your Bermuda Syndrome data files to $romdir/ports/$md_id before running the game."
+rp_module_help="Please copy your Bermuda Syndrome data files to $romdir/ports/bermudasyndrome before running the game."
 rp_module_repo="file http://cyxdown.free.fr/bs/bs-0.1.7.tar.bz2"
 rp_module_section="exp"
 rp_module_flags="!mali !x86"

--- a/scriptmodules/ports/chocolate-doom.sh
+++ b/scriptmodules/ports/chocolate-doom.sh
@@ -13,7 +13,7 @@
 rp_module_id="chocolate-doom"
 rp_module_desc="Chocolate Doom - Enhanced port of the official DOOM source"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/chocolate-doom/chocolate-doom/sdl2-branch/COPYING"
-rp_module_help="Please add your iWAD files to $romdir/ports/doom/ and reinstall $md_id to create entries for each game to EmulationStation. Run 'chocolate-doom-setup' to configure your controls and options."
+rp_module_help="Please add your iWAD files to $romdir/ports/doom/ and reinstall chocolate-doom to create entries for each game to EmulationStation. Run 'chocolate-doom-setup' to configure your controls and options."
 rp_module_repo="git https://github.com/chocolate-doom/chocolate-doom.git"
 rp_module_section="exp"
 rp_module_flags="!mali !x86"

--- a/scriptmodules/ports/crispy-doom-system.sh
+++ b/scriptmodules/ports/crispy-doom-system.sh
@@ -13,7 +13,7 @@
 rp_module_id="crispy-doom-system"
 rp_module_desc="Crispy Doom - Enhanced port of the official DOOM source"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/fabiangreffrath/crispy-doom/master/COPYING"
-rp_module_help="Please add your iWAD files to $romdir/ports/doom/ and reinstall $md_id to create entries for each game to EmulationStation. Run 'crispy-setup' to configure your controls and options."
+rp_module_help="Please add your iWAD files to $romdir/ports/doom/ and reinstall crispy-doom-system to create entries for each game to EmulationStation. Run 'crispy-setup' to configure your controls and options."
 rp_module_repo="git https://github.com/fabiangreffrath/crispy-doom.git"
 rp_module_section="exp"
 rp_module_flags="!mali !x86"

--- a/scriptmodules/ports/crispy-doom.sh
+++ b/scriptmodules/ports/crispy-doom.sh
@@ -13,7 +13,7 @@
 rp_module_id="crispy-doom"
 rp_module_desc="Crispy Doom - Enhanced port of the official DOOM source"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/fabiangreffrath/crispy-doom/master/COPYING"
-rp_module_help="Please add your iWAD files to $romdir/ports/doom/ and reinstall $md_id to create entries for each game to EmulationStation. Run 'crispy-setup' to configure your controls and options."
+rp_module_help="Please add your iWAD files to $romdir/ports/doom/ and reinstall crispy-doom to create entries for each game to EmulationStation. Run 'crispy-setup' to configure your controls and options."
 rp_module_repo="git https://github.com/fabiangreffrath/crispy-doom.git"
 rp_module_section="exp"
 rp_module_flags="!mali !x86"

--- a/scriptmodules/ports/eternity.sh
+++ b/scriptmodules/ports/eternity.sh
@@ -13,7 +13,7 @@
 rp_module_id="eternity"
 rp_module_desc="Chocolate Doom - Enhanced port of the official DOOM source"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/chocolate-doom/chocolate-doom/sdl2-branch/COPYING"
-rp_module_help="Please add your iWAD files to $romdir/ports/doom/ and reinstall $md_id to create entries for each game to EmulationStation. Run 'chocolate-doom-setup' to configure your controls and options."
+rp_module_help="Please add your iWAD files to $romdir/ports/doom/ and reinstall eternity to create entries for each game to EmulationStation. Run 'chocolate-doom-setup' to configure your controls and options."
 rp_module_repo="git https://github.com/team-eternity/eternity.git"
 rp_module_section="exp"
 rp_module_flags="!mali !x86"

--- a/scriptmodules/ports/pydance.sh
+++ b/scriptmodules/ports/pydance.sh
@@ -13,7 +13,7 @@
 rp_module_id="pydance"
 rp_module_desc="pydance - Open Source Dancing Game"
 rp_module_licence="MIT https://raw.githubusercontent.com/asb/pydance/master/LICENSE"
-rp_module_help="Be sure to add your songs to $md_conf_root/$md_id/songs. For more information about adding songs from other games to pydance, please take a look at the pydance homepage: https://icculus.org/pyddr/"
+rp_module_help="Be sure to add your songs to $configdir/ports/pydance/songs. For more information about adding songs from other games to pydance, please take a look at the pydance homepage: https://icculus.org/pyddr/"
 rp_module_repo="git https://github.com/mbenkmann/pydance.git"
 rp_module_section="exp"
 rp_module_flags="!mali"

--- a/scriptmodules/ports/rawgl.sh
+++ b/scriptmodules/ports/rawgl.sh
@@ -12,7 +12,7 @@
 
 rp_module_id="rawgl"
 rp_module_desc="rawgl - Another World Engine"
-rp_module_help="Please copy your Another World data files to $romdir/ports/$md_id before running the game."
+rp_module_help="Please copy your Another World data files to $romdir/ports/rawgl before running the game."
 rp_module_section="exp"
 rp_module_repo="git https://github.com/cyxx/rawgl.git"
 rp_module_flags="!mali !x86"

--- a/scriptmodules/ports/reminiscence.sh
+++ b/scriptmodules/ports/reminiscence.sh
@@ -14,7 +14,7 @@
 rp_module_id="reminiscence"
 rp_module_desc="REminiscence - Flashback Engine"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/Cheeseness/REminiscence/master/COPYING"
-rp_module_help="Please copy your Flashback data files to $romdir/ports/$md_id before running REminiscence."
+rp_module_help="Please copy your Flashback data files to $romdir/ports/reminiscence before running REminiscence."
 rp_module_section="exp"
 rp_module_flags="!mali !x86"
 

--- a/scriptmodules/ports/rott-darkwar.sh
+++ b/scriptmodules/ports/rott-darkwar.sh
@@ -14,7 +14,7 @@
 rp_module_id="rott-darkwar"
 rp_module_desc="rott-darkwar - Rise of the Triad - Dark War"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/zerojay/RoTT/master/COPYING"
-rp_module_help="Please add your full version ROTT files to $romdir/ports/$md_id/ to play."
+rp_module_help="Please add your full version ROTT files to $romdir/ports/rott-darkwar/ to play."
 rp_module_section="exp"
 rp_module_flags="!mali !x86"
 

--- a/scriptmodules/ports/rott-huntbgin.sh
+++ b/scriptmodules/ports/rott-huntbgin.sh
@@ -13,7 +13,7 @@
 rp_module_id="rott-huntbgin"
 rp_module_desc="rott - Rise of the Triad - The Hunt Begins (Shareware)"
 rp_module_licence="GPL2 https://raw.githubusercontent.com/zerojay/RoTT/master/COPYING"
-rp_module_help="Please add your shareware version ROTT files to $romdir/ports/$md_id/huntbgin to play."
+rp_module_help="Please add your shareware version ROTT files to $romdir/ports/rott-huntbgin/huntbgin to play."
 rp_module_repo="git https://github.com/zerojay/RoTT"
 rp_module_section="exp"
 rp_module_flags="!mali !x86"

--- a/scriptmodules/ports/sorr.sh
+++ b/scriptmodules/ports/sorr.sh
@@ -12,7 +12,7 @@
 
 rp_module_id="sorr"
 rp_module_desc="BennuGD interpreter for Streets of Rage Remake"
-rp_module_help="Please copy your SorR.dat file along with the mod and palettes folders into $romdir/ports/$md_id"
+rp_module_help="Please copy your SorR.dat file along with the mod and palettes folders into $romdir/ports/sorr"
 rp_module_section="exp"
 rp_module_flags="!x86 !x11 !mali"
 


### PR DESCRIPTION
Just use scriptmodule name instead.

Likewise $md_conf_root is also not yet available -- use $configdir or $configdir/ports, as appropriate.