### PR TITLE
Add script OpenJKDF2

### DIFF
--- a/scriptmodules/ports/openjkdf2.sh
+++ b/scriptmodules/ports/openjkdf2.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="openjkdf2"
+rp_module_desc="OpenJKDF2 is a function-by-function reimplementation of Dark Forces 2."
+rp_module_licence="OTHER https://github.com/shinyquagsire23/OpenJKDF2/blob/master/LICENSE.md"
+rp_module_repo="git https://github.com/shinyquagsire23/OpenJKDF2.git v0.8.8"
+rp_module_section="exp"
+
+function depends_openjkdf2() {
+    local depends=(
+        git build-essential cmake make python3 python3-pip bison imagemagick libgtk-3-dev protobuf-compiler zsh
+        clang libsdl2-dev libsdl2-mixer-dev libopenal-dev libglew-dev libssl-dev libprotobuf-dev
+    )
+
+    getDepends "${depends[@]}"
+
+    # Note: This also needs to run: "pip3 install cogapp"
+}
+
+function sources_openjkdf2() {
+    gitPullOrClone
+}
+
+function build_openjkdf2() {
+    export CC=clang
+    export CXX=clang++
+
+    chmod +x build_linux64.sh
+    ./build_linux64.sh
+
+    md_ret_require=build_linux64/openjkdf2
+}
+
+function install_openjkdf2() {
+    md_ret_files=(
+        build_linux64/openjkdf2
+        build_linux64/libGameNetworkingSockets.so
+        build_linux64/libprotobuf.so.3.21.4.0
+    )
+}
+
+function game_data_openjkdf2() {
+    chmod -R $user:$user "$romdir/ports/openjkdf2"
+}
+
+function add_games_openjkdf2() {
+    if [[ -f "$romdir/openjkdf2/openjkdf2/Episode/JK1.GOB" ]]; then
+        addPort "$md_id" "openjkdf2" "Star Wars - Jedi Knight - Dark Forces II" "$md_inst/openjkdf2 %ROM%" ""
+    fi
+    if [[ -f "$romdir/openjkdf2/openjkmots/Episode/JKM.GOO" ]]; then
+        addPort "$md_id" "openjkdf2" "Star Wars - Jedi Knight - Mysteries of the Sith" "$md_inst/openjkdf2 %ROM%" "-motsCompat"
+    fi
+    if [[ ! -f "$romdir/openjkdf2/openjkdf2/Episode/JK1.GOB" ]] && [[ ! -f "$romdir/openjkdf2/openjkmots/Episode/JKM.GOO" ]]; then
+        addPort "$md_id" "openjkdf2" "Star Wars - Jedi Knight - Dark Forces II" "$md_inst/openjkdf2 %ROM%" ""
+        addPort "$md_id" "openjkdf2" "Star Wars - Jedi Knight - Mysteries of the Sith" "$md_inst/openjkdf2 %ROM%" "-motsCompat"
+    fi
+}
+
+function configure_openjkdf2() {
+    mkRomDir "ports/openjkdf2"
+
+    add_games_openjkdf2
+
+    moveConfigDir "$home/.local/share/OpenJKDF2" "$romdir/ports/openjkdf2"
+
+    [[ "$md_mode" == "install" ]] && game_data_openjkdf2
+}


### PR DESCRIPTION
New installer OpenJKDF2, a function-by-function reimplementation of DF2 in C, with 64-bit ports to MacOS and Linux.

https://github.com/shinyquagsire23/OpenJKDF2
