### PR TITLE
bgm123 update

### DIFF
--- a/scriptmodules/supplementary/bgm123.sh
+++ b/scriptmodules/supplementary/bgm123.sh
@@ -170,7 +170,7 @@ function toggle_bgm123() {
         iniGet "sleep_timer"
 
         local autostart_text='(sleep '"${ini_value:-10}"'; pgrep emulationstatio >/dev/null && bash "'"$init"'") & #bgm123'
-        local bashrc_text='[[ "$(tty)" == "/dev/tty1" ]] && (bash "'"$killscript"'" &) #bgm123'
+        local bashrc_text='[[ "$(tty)" == "/dev/tty1" ]] && bash "'"$killscript"'" #bgm123'
         local onstart_text='bash "'"$fadescript"'" -STOP & #bgm123'
         local onend_text='(sleep 1; bash "'"$fadescript"'" -CONT) & #bgm123'
 
@@ -303,7 +303,7 @@ function gui_bgm123() {
                     fi
                     ;;
                 N)
-                    su "$user" -c "(bash $killscript; bash $init) &"
+                    su "$user" -c "(bash $killscript; sleep 1; bash $init) &"
                     ;;
             esac
         else

--- a/scriptmodules/supplementary/bgm123.sh
+++ b/scriptmodules/supplementary/bgm123.sh
@@ -22,7 +22,7 @@ function _get_vars_bgm123() {
         [bashrc]="$home/.bashrc"
         [onstart]="$configdir/all/runcommand-onstart.sh"
         [onend]="$configdir/all/runcommand-onend.sh"
-        [autoconf]="$configdir/all/$md_id.cfg"
+        [config]="$configdir/all/$md_id.cfg"
         [menudir]="$datadir/retropiemenu"
         [init]="$md_inst/bgm_start.sh"
         [killscript]="$md_inst/bgm_stop.sh"
@@ -41,7 +41,7 @@ function depends_bgm123() {
 
 function install_bin_bgm123() {
     local vars=(
-        'autoconf'
+        'config'
         'menudir'
     )
     $(_get_vars_bgm123 "${vars[@]}")
@@ -53,10 +53,10 @@ function install_bin_bgm123() {
         'bgm_fade.sh'
     )
 
-    # copy scripts and include config
+    # copy scripts and source config
     for file in "${scripts[@]}"; do
         cp "$md_data/$file" "$md_inst"
-        sed -i 's|.*#autoconf.*|source "'"$autoconf"'" #autoconf|' "$md_inst/$file"
+        sed -i 's|.*#config.*|source "'"$config"'" #config|' "$md_inst/$file"
     done
 
     # create rp menu items
@@ -71,7 +71,7 @@ function configure_bgm123() {
         'bashrc'
         'onstart'
         'onend'
-        'autoconf'
+        'config'
         'menudir'
     )
     $(_get_vars_bgm123 "${vars[@]}")
@@ -125,11 +125,11 @@ function configure_bgm123() {
     iniSet "music_player" "mpg123"
     iniSet "music_dir" "$share"
     iniSet "mapped_volume" "enabled"
-    copyDefaultConfig "$tmp" "$autoconf"
+    copyDefaultConfig "$tmp" "$config"
     rm -f "$tmp"
 
     # check for enable
-    iniConfig "=" '"' "$autoconf"
+    iniConfig "=" '"' "$config"
     iniGet "status"
     [[ "$ini_value" == "enabled" ]] && toggle_bgm123 on
 
@@ -146,7 +146,7 @@ function toggle_bgm123() {
         'bashrc'
         'onstart'
         'onend'
-        'autoconf'
+        'config'
         'init'
         'killscript'
         'fadescript'
@@ -166,7 +166,7 @@ function toggle_bgm123() {
             chown $user:$user "$file"
         done
 
-        iniConfig "=" '"' "$autoconf"
+        iniConfig "=" '"' "$config"
         iniGet "sleep_timer"
 
         local autostart_text='(sleep '"${ini_value:-10}"'; pgrep emulationstatio >/dev/null && bash "'"$init"'") & #bgm123'
@@ -208,7 +208,7 @@ function enable_bgm123() {
 function gui_bgm123() {
     local vars=(
         'autostart'
-        'autoconf'
+        'config'
         'init'
         'killscript'
         'fadescript'
@@ -216,7 +216,7 @@ function gui_bgm123() {
     $(_get_vars_bgm123 "${vars[@]}")
 
     while true; do
-        iniConfig "=" '"' "$autoconf"
+        iniConfig "=" '"' "$config"
 
         # check if bgm code is actually enabled in autostart
         local status="disabled"

--- a/scriptmodules/supplementary/bgm123.sh
+++ b/scriptmodules/supplementary/bgm123.sh
@@ -170,17 +170,17 @@ function toggle_bgm123() {
         iniGet "sleep_timer"
 
         local autostart_text='(sleep '"${ini_value:-10}"'; pgrep emulationstatio >/dev/null && bash "'"$init"'") & #bgm123'
+        local bashrc_text='[[ "$(tty)" == "/dev/tty1" ]] && (bash "'"$killscript"'" &) #bgm123'
         local onstart_text='bash "'"$fadescript"'" -STOP & #bgm123'
         local onend_text='(sleep 1; bash "'"$fadescript"'" -CONT) & #bgm123'
-        local bashrc_text='[[ "$(tty)" == "/dev/tty1" ]] && (bash "'"$killscript"'" &) #bgm123'
 
         # add enable text at the top of autostart file...
         echo "$(echo $autostart_text; cat $autostart)" > "$autostart"
 
         # ...and at the end of other files
+        echo "$bashrc_text" >> "$bashrc"
         echo "$onstart_text" >> "$onstart"
         echo "$onend_text" >> "$onend"
-        echo "$bashrc_text" >> "$bashrc"
 
         printMsgs "console" "Background music enabled."
     else

--- a/scriptmodules/supplementary/bgm123.sh
+++ b/scriptmodules/supplementary/bgm123.sh
@@ -174,9 +174,11 @@ function toggle_bgm123() {
         local onend_text='(sleep 1; bash "'"$fadescript"'" -CONT) & #bgm123'
         local bashrc_text='[[ "$(tty)" == "/dev/tty1" ]] && (bash "'"$killscript"'" &) #bgm123'
 
-        # add lines to the TOP of autostart, onstart, and the BOTTOM of onend, bashrc
+        # add enable text at the top of autostart file...
         echo "$(echo $autostart_text; cat $autostart)" > "$autostart"
-        echo "$(echo $onstart_text; cat $onstart)" > "$onstart"
+
+        # ...and at the end of other files
+        echo "$onstart_text" >> "$onstart"
         echo "$onend_text" >> "$onend"
         echo "$bashrc_text" >> "$bashrc"
 

--- a/scriptmodules/supplementary/bgm123/bgm_fade.sh
+++ b/scriptmodules/supplementary/bgm123/bgm_fade.sh
@@ -9,7 +9,7 @@
 # https://github.com/crcerror/RetroPie-Shares/blob/master/BGM_vol_fade.sh
 #
 
-source #autoconf
+source #config
 
 # avoid multiple starts
 wait=0

--- a/scriptmodules/supplementary/bgm123/bgm_start.sh
+++ b/scriptmodules/supplementary/bgm123/bgm_start.sh
@@ -2,7 +2,7 @@
 
 # bgm123 init script for RetroPie
 
-source #autoconf
+source #config
 
 vcgencmd force_audio hdmi 1 >/dev/null && sleep 1
 mpg123 -Z -@- >/dev/null 2>&1 < <(find "$music_dir" -type f -iname "*.mp3")

--- a/scriptmodules/supplementary/bgm123/bgm_start.sh
+++ b/scriptmodules/supplementary/bgm123/bgm_start.sh
@@ -4,5 +4,4 @@
 
 source #config
 
-vcgencmd force_audio hdmi 1 >/dev/null && sleep 1
 mpg123 -Z -@- >/dev/null 2>&1 < <(find "$music_dir" -type f -iname "*.mp3")

--- a/scriptmodules/supplementary/bgm123/bgm_stop.sh
+++ b/scriptmodules/supplementary/bgm123/bgm_stop.sh
@@ -2,7 +2,7 @@
 
 # bgm123 kill script for RetroPie
 
-source #autoconf
+source #config
 
 vcgencmd force_audio hdmi 0 >/dev/null && sleep 0.1
 pkill "$music_player"

--- a/scriptmodules/supplementary/bgm123/bgm_stop.sh
+++ b/scriptmodules/supplementary/bgm123/bgm_stop.sh
@@ -4,7 +4,6 @@
 
 source #config
 
-vcgencmd force_audio hdmi 0 >/dev/null && sleep 0.1
 pkill "$music_player"
 
 # if killed while stopped (music paused), process will not terminate correctly.


### PR DESCRIPTION
Mostly minor cosmetic stuff but the *vcgencmd* stuff was causing a major bug that randomly broke sound for the whole system until you do a reboot (or manually start `mpg123` from command line.)

Without it, it just cuts off the first 1 second or so when first starting up or manually skipping tracks (not when one track ends and the next begins I don't think). It's not ideal but it's better than no audio at all.

I've tried moving it around and putting it in different places and every time, it eventually ends up killing my audio completely (games too).

User may manually enable the `force_audio` from command line if desired, it's just this trying to do it automatically that fouls it up.