### PR TITLE
Revert "fixed the link to game dir"

### DIFF
--- a/scriptmodules/ports/openjk_ja.sh
+++ b/scriptmodules/ports/openjk_ja.sh
@@ -34,7 +34,7 @@ function sources_openjk_ja() {
 function build_openjk_ja() {
     mkdir "$md_build/build"
     cd "$md_build/build"
-    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$romdir/ports/jediacademy ..
+    cmake -DCMAKE_BUILD_TYPE=Release ..
     make clean
     make
 
@@ -58,7 +58,6 @@ function install_openjk_ja() {
 }
 
 function configure_openjk_ja() {
-    mkRomDir "ports/jediacademy"
     local launcher_sp="$md_inst/openjk_sp.$(_arch_openjk_ja)"
     local launcher_mp="$md_inst/openjk.$(_arch_openjk_ja)"
     local params=()
@@ -69,9 +68,11 @@ function configure_openjk_ja() {
     addPort "$md_id" "jediacademy" "Star Wars - Jedi Knight - Jedi Academy (SP)" "$script %ROM% ${params[*]}" "sp"
     addPort "$md_id" "jediacademy" "Star Wars - Jedi Knight - Jedi Academy (MP)" "$script %ROM% ${params[*]}" "mp"
 
-    moveConfigDir "$home/.local/share/openjk" "$romdir/ports/jediacademy"
+    moveConfigDir "$home/.local/share/openjk" "$md_conf_root/jediacademy/openjk"
 
     [[ "$md_mode" == "remove" ]] && return
+
+    mkRomDir "ports/jediacademy"
 
     # link game data to install dir
     ln -snf "$romdir/ports/jediacademy" "$md_inst/base"

--- a/scriptmodules/ports/openjk_jo.sh
+++ b/scriptmodules/ports/openjk_jo.sh
@@ -34,7 +34,7 @@ function sources_openjk_jo() {
 function build_openjk_jo() {
     mkdir "$md_build/build"
     cd "$md_build/build"
-    cmake -DCMAKE_INSTALL_PREFIX=$romdir/ports/jedioutcast -DBuildJK2SPEngine=ON -DBuildJK2SPGame=ON -DBuildJK2SPRdVanilla=ON -DCMAKE_BUILD_TYPE=Release ..
+    cmake -DBuildJK2SPEngine=ON -DBuildJK2SPGame=ON -DBuildJK2SPRdVanilla=ON -DCMAKE_BUILD_TYPE=Release ..
     make clean
     make
 
@@ -56,7 +56,6 @@ function install_openjk_jo() {
 }
 
 function configure_openjk_jo() {
-    mkRomDir "ports/jedioutcast"
     local launcher_jo_sp="$md_inst/openjo_sp.$(_arch_openjk_jo)"
     local params=("+set com_jk2 1")
     isPlatform "mesa" && params+=("+set cl_renderer opengl1")
@@ -64,10 +63,12 @@ function configure_openjk_jo() {
     local script="$md_inst/launch-$md_id.sh"
 
     addPort "$md_id" "jedioutcast" "Star Wars - Jedi Knight - Jedi Outcast (SP)" "$script %ROM% ${params[*]}" "sp"
-    moveConfigDir "$home/.local/share/openjo" "$romdir/ports/jedioutcast"
+    moveConfigDir "$home/.local/share/openjo" "$md_conf_root/jedioutcast/openjo"
 
     [[ "$md_mode" == "remove" ]] && return
-	
+
+    mkRomDir "ports/jedioutcast"
+
     # link game data to install dir
     ln -snf "$romdir/ports/jedioutcast" "$md_inst/base"
 


### PR DESCRIPTION
This reverts commit 570f2a7a7dfee0e2dd31042c76184c031b984604.

openjk_jo
openjk_ja

What exactly was the issue here? I've just reinstalled both of these from latest master branch, using the ~~old-version~~ reverted scripts, and they all (both SP + JA_MP) worked fine. What was this meant to accomplish?
