### PR TITLE
openjk_ja.sh - rework game data / .so file handling

### DIFF
--- a/scriptmodules/ports/openjk_ja.sh
+++ b/scriptmodules/ports/openjk_ja.sh
@@ -44,15 +44,19 @@ function build_openjk_ja() {
 }
 
 function install_openjk_ja() {
+    mkdir -p "$md_inst/base"
+
+    local lib
+    for lib in game/jampgame cgame/cgame ui/ui; do
+        cp -v "$md_build/build/codemp/$lib$(_arch_openjk_ja).so" "$md_inst/base"
+    done
+
     md_ret_files=(
         "build/openjkded.$(_arch_openjk_ja)"
         "build/openjk_sp.$(_arch_openjk_ja)"
         "build/openjk.$(_arch_openjk_ja)"
         "build/code/game/jagame$(_arch_openjk_ja).so"
         "build/code/rd-vanilla/rdsp-vanilla_$(_arch_openjk_ja).so"
-        "build/codemp/game/jampgame$(_arch_openjk_ja).so"
-        "build/codemp/cgame/cgame$(_arch_openjk_ja).so"
-        "build/codemp/ui/ui$(_arch_openjk_ja).so"
         "build/codemp/rd-vanilla/rd-vanilla_$(_arch_openjk_ja).so"
     )
 }
@@ -74,13 +78,10 @@ function configure_openjk_ja() {
 
     mkRomDir "ports/jediacademy"
 
-    # link game data to install dir
-    ln -snf "$romdir/ports/jediacademy" "$md_inst/base"
-
-    # link required libs to game dir (required for multiplayer)
-    for lib in ui cgame jampgame; do
-        ln -sf "$md_inst/$lib$(_arch_openjk_ja).so" "$romdir/ports/jediacademy/$lib$(_arch_openjk_ja).so"
-        chown -h $user:$user "$romdir/ports/jediacademy/$lib$(_arch_openjk_ja).so"
+    # softlink game files to base dir
+    local num
+    for num in {0..3}; do
+        ln -sf "$romdir/ports/jediacademy/assets$num.pk3" "$md_inst/base/assets$num.pk3"
     done
 
     cat > "$script" << _EOF_


### PR DESCRIPTION
Prevents error on SMB backup.

Jedi Academy (openjk_ja)

**The requirements**: it needs to look in `$md_inst/base` and find 1) the user-supplied `.pk3` game data files, and 2) the package-side `.so` files.

**The situation**: currently, this is accomplished by making `base` a symlink to `$romdir/ports/jediacademy` (herein: "`${game_dir}`") and then put links *in* `${game_dir}` back to the `.so` files in `$md_inst`:

https://github.com/Exarkuniv/RetroPie-Extra/blob/76554feae7b1dab57691e53fc2d642f445716e3a/scriptmodules/ports/openjk_ja.sh#L77-L84

It *looks in* `base` and *sees in* `${game_dir}`, wherein it sees (original) game files and (links to) `.so` files.

**The problem**: When backing up via SMB, this links to outside the shared folders -- which is not allowed by default for security purposes -- requiring user-input on the client-side to skip the protected files and continue with the backup operation.

**The solution**: this is where the scriptmodule *originally* just *copied* the `.so` files into `${game_dir}` and just...left them there (like an *animal*). I wanted to link them instead and then that's when the problem happened.

So, we cannot have links *in* the shared folder pointing *to outside*...*but*, we *can* have links *from* outside that do point *inside* -- *that* should *not* be a security risk, and should not cause any problems when making a backup.

The new configuration will have `$md_inst/base` as a real directory (not a symlink), with the real `.so` files in. Then with symlinks *in* `base` that are links back to the real `.pk3` files in `${game_dir}`.