### PR TITLE
update bgm123.sh - improve gamepad menu control

### DIFF
--- a/scriptmodules/supplementary/bgm123.sh
+++ b/scriptmodules/supplementary/bgm123.sh
@@ -287,7 +287,7 @@ function gui_bgm123() {
                             printMsgs "dialog" "Music directory set to default ($datadir/bgm)\n\nSkip track or restart to apply changes."
                             ;;
                         2)
-                            music_dir=$(dialog --backtitle "$__backtitle" --title "Music directory" --dselect "$music_dir" 12 60 2>&1 >/dev/tty)
+                            music_dir=$(dialog --backtitle "$__backtitle" --title "Music directory" --dselect "$datadir/bgm" 12 60 2>&1 >/dev/tty)
                             if [[ -n "$music_dir" ]]; then
                                 iniSet "music_dir" "$music_dir"
                                 printMsgs "dialog" "Music directory set to $music_dir\n\nSkip track or restart to apply changes."


### PR DESCRIPTION
"choose own music dir" - start from default location, not current selection.

The `dialog --dselect` widget is basically a glorified autocomplete. Going "back" a level requires backspace, which is not programmed on our `joy2key` gamepads.

Solution: just start from the root `bgm` directory each time when choosing location (user can still cancel operation to keep current selection.)