### PR TITLE
Align License rp_module_licence format to RetroPie-Setup

### DIFF
--- a/scriptmodules/libretrocores/lr-2048.sh
+++ b/scriptmodules/libretrocores/lr-2048.sh
@@ -12,7 +12,7 @@
 
 rp_module_id="lr-2048"
 rp_module_desc="2048 engine - 2048 port for libretro"
-rp_module_licence="Unl https://raw.githubusercontent.com/libretro/libretro-2048/master/COPYING"
+rp_module_licence="UNL https://raw.githubusercontent.com/libretro/libretro-2048/master/COPYING"
 rp_module_repo="git https://github.com/libretro/libretro-2048.git master"
 rp_module_section="exp"
 rp_module_flags=""

--- a/scriptmodules/libretrocores/lr-duckstation.sh
+++ b/scriptmodules/libretrocores/lr-duckstation.sh
@@ -13,7 +13,7 @@
 rp_module_id="lr-duckstation"
 rp_module_desc="PlayStation emulator - Duckstation for libretro"
 rp_module_help="ROM Extensions: .exe .cue .bin .chd .psf .m3u .pbp\n\nCopy your PlayStation roms to $romdir/psx\n\nCopy compatible BIOS files to $biosdir"
-rp_module_licence="PROP https://creativecommons.org/licenses/by-nc-nd/4.0"
+rp_module_licence="CC-BY-NC-ND-4.0 https://creativecommons.org/licenses/by-nc-nd/4.0"
 rp_module_section="exp"
 rp_module_flags="!all arm !armv6 aarch64 64bit"
 

--- a/scriptmodules/libretrocores/lr-oberon.sh
+++ b/scriptmodules/libretrocores/lr-oberon.sh
@@ -13,7 +13,7 @@
 rp_module_id="lr-oberon"
 rp_module_desc="Oberon RISC emulator for libretro"
 rp_module_help="ROM Extensions: .dsk\n\nOberon RISC disk images are copied to $romdir/ports/oberon"
-rp_module_licence="Unknown https://inf.ethz.ch/personal/wirth/ProjectOberon/license.txt"
+rp_module_licence="CUSTOM https://inf.ethz.ch/personal/wirth/ProjectOberon/license.txt"
 rp_module_repo="git https://github.com/libretro/oberon-risc-emu master"
 rp_module_section="exp"
 rp_module_flags=""

--- a/scriptmodules/libretrocores/lr-potator.sh
+++ b/scriptmodules/libretrocores/lr-potator.sh
@@ -13,7 +13,7 @@
 rp_module_id="lr-potator"
 rp_module_desc="Watara Supervision emulator based on Normmatt version - Potator port for libretro"
 rp_module_help="ROM Extensions: .sv .zip .7z\n\nCopy your Watara Supervision roms to $romdir/svision"
-rp_module_licence="Unl https://raw.githubusercontent.com/libretro/potator/master/LICENSE"
+rp_module_licence="UNL https://raw.githubusercontent.com/libretro/potator/master/LICENSE"
 rp_module_section="exp"
 rp_module_repo="git https://github.com/libretro/potator.git master"
 rp_module_flags=""

--- a/scriptmodules/ports/0ad.sh
+++ b/scriptmodules/ports/0ad.sh
@@ -11,7 +11,7 @@
 
 rp_module_id="0ad"
 rp_module_desc="0ad - Battle of Survival - is a futuristic real-time strategy game"
-rp_module_licence="GNU https://libregamewiki.org/GNU_General_Public_License"
+rp_module_licence="GPL2 https://svn.wildfiregames.com/public/ps/trunk/license_gpl-2.0.txt"
 rp_module_section="exp"
 rp_module_flags="!mali rpi4"
 

--- a/scriptmodules/ports/adom.sh
+++ b/scriptmodules/ports/adom.sh
@@ -13,7 +13,7 @@
 rp_module_id="adom"
 rp_module_desc="Ancient Domains of Mystery - a free roguelike by Thomas Biskup"
 rp_module_help="A keyboard is required to play. Press SHIFT+Q to exit the game."
-rp_module_licence="PROP"
+rp_module_licence="PROP https://www.adom.de"
 rp_module_section="exp"
 rp_module_flags="!all arm"
 

--- a/scriptmodules/ports/berusky.sh
+++ b/scriptmodules/ports/berusky.sh
@@ -11,7 +11,7 @@
 
 rp_module_id="berusky"
 rp_module_desc="berusky - Advanced sokoban clone with nice graphics"
-rp_module_licence="GNU https://libregamewiki.org/GNU_General_Public_License"
+rp_module_licence="GPL2 https://www.anakreon.cz/berusky1.html"
 rp_module_section="exp"
 rp_module_flags="!mali !x86"
 

--- a/scriptmodules/ports/boswars.sh
+++ b/scriptmodules/ports/boswars.sh
@@ -11,7 +11,7 @@
 
 rp_module_id="boswars"
 rp_module_desc="boswars - Battle of Survival - is a futuristic real-time strategy game"
-rp_module_licence="GNU https://libregamewiki.org/GNU_General_Public_License"
+rp_module_licence="GPL2 https://codeberg.org/boswars/boswars/src/branch/master/LICENSE.txt"
 rp_module_section="exp"
 rp_module_flags="!mali !x86"
 

--- a/scriptmodules/ports/chopper258.sh
+++ b/scriptmodules/ports/chopper258.sh
@@ -14,7 +14,7 @@ rp_module_id="chopper258"
 rp_module_desc="Chopper Commando Revisited - a modern port of Chopper Commando (DOS, 1990), written by Mark Currie and ported by loadzero"
 rp_module_help="A keyboard is required."
 rp_module_repo="git https://github.com/loadzero/chopper258 master"
-rp_module_licence="freeware https://raw.githubusercontent.com/loadzero/chopper258/master/CREDITS.txt"
+rp_module_licence="FREEWARE https://raw.githubusercontent.com/loadzero/chopper258/master/CREDITS.txt"
 rp_module_section="exp"
 rp_module_flags="sdl2"
 

--- a/scriptmodules/ports/cytadela.sh
+++ b/scriptmodules/ports/cytadela.sh
@@ -11,7 +11,7 @@
 
 rp_module_id="cytadela"
 rp_module_desc="Cytadela project - a conversion of an Amiga first person shooter"
-rp_module_licence="GNU http://cytadela.sourceforge.net/license.php"
+rp_module_licence="GPL3 http://cytadela.sourceforge.net/license.php"
 rp_module_section="exp"
 rp_module_flags="noinstclean"
 

--- a/scriptmodules/ports/devilutionx.sh
+++ b/scriptmodules/ports/devilutionx.sh
@@ -12,7 +12,7 @@
 
 rp_module_id="devilutionx"
 rp_module_desc="devilutionx - Diablo Engine"
-rp_module_licence="https://raw.githubusercontent.com/diasurgical/devilutionX/master/LICENSE"
+rp_module_licence="SUL1 https://raw.githubusercontent.com/diasurgical/devilutionX/master/LICENSE.md"
 rp_module_help="Copy your original diabdat.mpq file from Diablo to $romdir/ports/devilutionx."
 rp_module_repo="wget https://github.com/diasurgical/devilutionX/releases/download/1.3.0/devilutionx-linux-armhf.zip"
 rp_module_section="exp"
@@ -30,7 +30,7 @@ function install_devilutionx() {
     cd devilutionx-linux-armhf
     dpkg -i ./devilutionx_1.3.0_armhf.deb
     md_ret_files=(
-          	devilutionx-linux-armhf/devilutionx
+        devilutionx-linux-armhf/devilutionx
 		devilutionx-linux-armhf/devilutionx.mpq
 		devilutionx-linux-armhf/README.txt 
 		devilutionx-linux-armhf/LICENSE.CC-BY.txt

--- a/scriptmodules/ports/dosbox-x.sh
+++ b/scriptmodules/ports/dosbox-x.sh
@@ -12,7 +12,7 @@
 rp_module_id="dosbox-x"
 rp_module_desc="Testing of a new DOSbox system"
 rp_module_help="ROM Extensions: .bat .com .exe .sh .conf\n\nCopy your DOS games to ports/dosbox"
-rp_module_licence="GNU https://raw.githubusercontent.com/joncampbell123/dosbox-x/master/COPYING"
+rp_module_licence="GPL2 https://raw.githubusercontent.com/joncampbell123/dosbox-x/master/COPYING"
 rp_module_repo="git https://github.com/joncampbell123/dosbox-x.git master"
 rp_module_section="exp"
 rp_module_flags=""

--- a/scriptmodules/ports/dunelegacy.sh
+++ b/scriptmodules/ports/dunelegacy.sh
@@ -12,7 +12,7 @@
 rp_module_id="dunelegacy"
 rp_module_desc="Dune Legacy - Dune 2 Building of a Dynasty port"
 rp_module_help="Please put your data files in the roms/ports/dunelegacy/data folder"
-rp_module_licence="GNU 2.0 https://sourceforge.net/p/dunedynasty/dunedynasty/ci/master/tree/COPYING"
+rp_module_licence="GPL2 https://sourceforge.net/p/dunedynasty/dunedynasty/ci/master/tree/COPYING"
 rp_module_repo="git git://dunelegacy.git.sourceforge.net/gitroot/dunelegacy/dunelegacy master"
 rp_module_section="exp"
 rp_module_flags="!mali"

--- a/scriptmodules/ports/fallout1.sh
+++ b/scriptmodules/ports/fallout1.sh
@@ -12,7 +12,7 @@
 
 rp_module_id="fallout1"
 rp_module_desc="Fallout Community Edition"
-rp_module_licence="GNU https://raw.githubusercontent.com/alexbatalov/fallout1-ce/main/LICENSE.md"
+rp_module_licence="SUL1 https://raw.githubusercontent.com/alexbatalov/fallout1-ce/main/LICENSE.md"
 rp_module_help="Copy over the master.dat, critter.dat, and data folder to ports/fallout1. EVERYTHING needs to be lower case or it will not work"
 rp_module_section="exp"
 rp_module_flags=""

--- a/scriptmodules/ports/fallout2.sh
+++ b/scriptmodules/ports/fallout2.sh
@@ -12,7 +12,7 @@
 
 rp_module_id="fallout2"
 rp_module_desc="Fallout 2 Community Edition"
-rp_module_licence="GNU https://raw.githubusercontent.com/alexbatalov/fallout2-ce/main/LICENSE.md"
+rp_module_licence="SUL1 https://raw.githubusercontent.com/alexbatalov/fallout2-ce/main/LICENSE.md"
 rp_module_help="Copy over the master.dat, critter.dat, patch000.dat, and data folder to ports/fallout2"
 rp_module_section="exp"
 rp_module_flags=""

--- a/scriptmodules/ports/fs2open.sh
+++ b/scriptmodules/ports/fs2open.sh
@@ -12,7 +12,7 @@
 
 rp_module_id="fs2open"
 rp_module_desc="FreeSpace 2 Open - Origin Repository for FreeSpace 2"
-rp_module_licence="https://raw.githubusercontent.com/scp-fs2open/fs2open.github.com/master/Unlicense.md"
+rp_module_licence="UNL https://raw.githubusercontent.com/scp-fs2open/fs2open.github.com/master/Unlicense.md"
 rp_module_help="FreeSpace2 \nInstall files \n
 root_fs2.vp\n
 smarty_fs2.vp\n

--- a/scriptmodules/ports/gtkboard.sh
+++ b/scriptmodules/ports/gtkboard.sh
@@ -12,7 +12,7 @@
 
 rp_module_id="gtkboard"
 rp_module_desc="Board games system"
-rp_module_licence="gtkboard.sourceforge.net"
+rp_module_licence="GPL2 https://gtkboard.sourceforge.net"
 rp_module_section="exp"
 rp_module_flags="!mali !x86"
 

--- a/scriptmodules/ports/hheretic.sh
+++ b/scriptmodules/ports/hheretic.sh
@@ -12,7 +12,7 @@
 rp_module_id="hheretic"
 rp_module_desc="Heretic GL port"
 rp_module_help="Please put your heretic.wad in the roms/ports/heretic folder" 
-rp_module_licence="GNU https://sourceforge.net/p/hhexen/hhexen/ci/master/tree/LICENSE.md"
+rp_module_licence="GPL2 https://sourceforge.net/p/hhexen/hhexen/ci/master/tree/LICENSE"
 rp_module_repo="wget https://sourceforge.net/projects/hhexen/files/hheretic/0.2.3/hheretic-0.2.3-src.tgz"
 rp_module_section="exp"
 rp_module_flags="!mali"

--- a/scriptmodules/ports/hhexen.sh
+++ b/scriptmodules/ports/hhexen.sh
@@ -12,7 +12,7 @@
 rp_module_id="hhexen"
 rp_module_desc="Hexen GL port"
 rp_module_help="Please put your heretic.wad in the roms/ports/hexen folder" 
-rp_module_licence="GNU https://sourceforge.net/p/hhexen/hhexen/ci/master/tree/LICENSE.md"
+rp_module_licence="GPL2 https://sourceforge.net/p/hhexen/hhexen/ci/master/tree/LICENSE"
 rp_module_repo="wget https://sourceforge.net/projects/hhexen/files/hhexen/1.6.3/hhexen-1.6.3-src.tgz"
 rp_module_section="exp"
 rp_module_flags="!mali"

--- a/scriptmodules/ports/ja2.sh
+++ b/scriptmodules/ports/ja2.sh
@@ -12,7 +12,7 @@
 
 rp_module_id="ja2"
 rp_module_desc="Jagged Alliance 2"
-rp_module_licence="GPL https://github.com/ja2-stracciatella/ja2-stracciatella"
+rp_module_licence="FREEWARE https://github.com/ja2-stracciatella/ja2-stracciatella/blob/master/README.md#license"
 rp_module_repo="git https://github.com/ja2-stracciatella/ja2-stracciatella.git v0.18.0"
 rp_module_help=" Copy over game data files and folders from your PC to ports/ja2"
 rp_module_section="exp"

--- a/scriptmodules/ports/jfsw.sh
+++ b/scriptmodules/ports/jfsw.sh
@@ -13,7 +13,7 @@
 rp_module_id="jfsw"
 rp_module_desc="JFSW - Shadow Warrior source port by Jonathon Fowler"
 rp_module_help="Place your registered version game files in $romdir/ports/shadowwarrior"
-rp_module_licence="GPL https://github.com/jonof/jfsw/blob/master/GPL.TXT"
+rp_module_licence="GPL2 https://github.com/jonof/jfsw/blob/master/GPL.TXT"
 rp_module_repo="git https://github.com/jonof/jfsw.git master"
 rp_module_section="exp"
 rp_module_flags=""

--- a/scriptmodules/ports/kraptor.sh
+++ b/scriptmodules/ports/kraptor.sh
@@ -12,7 +12,7 @@
 
 rp_module_id="kraptor"
 rp_module_desc="Shoot em up scroller game"
-rp_module_licence="https://lutris.net/games/kraptor/"
+rp_module_licence="MIT https://sourceforge.net/projects/kraptor/files/kraptor_source_code/final_apr_03_2004/"
 rp_module_section="exp"
 rp_module_flags="!mali !x86"
 

--- a/scriptmodules/ports/opendune.sh
+++ b/scriptmodules/ports/opendune.sh
@@ -13,7 +13,7 @@
 rp_module_id="opendune"
 rp_module_desc="OpenDune - Dune 2 port using the OpenRA engine"
 rp_module_help="Please put your data files in the roms/ports/opendune/data folder"
-rp_module_licence="GNU https://github.com/OpenDUNE/OpenDUNE/blob/master/COPYING"
+rp_module_licence="GPL2 https://github.com/OpenDUNE/OpenDUNE/blob/master/COPYING"
 rp_module_repo="git https://github.com/OpenDUNE/OpenDUNE.git master"
 rp_module_section="exp"
 rp_module_flags="noinstclean"

--- a/scriptmodules/ports/openjkdf2.sh
+++ b/scriptmodules/ports/openjkdf2.sh
@@ -14,7 +14,7 @@ rp_module_desc="OpenJKDF2 is a function-by-function reimplementation of Dark For
 # I hate this really long line.  I couldn't get all the information to display otherwise.
 #
 rp_module_help="Data must be installed manually.\nData for Jedi Knight - Dark Forces 2 goes into $romdir/openjkdf2/openjkdf2.\nData for Jedi Knight - Mysteries of the Sith goes into $romdir/openjkdf2/openjkmots.\nFor both games the 'episode' 'player' 'resource' and 'Music' directories must be copied into their repsective folders."
-rp_module_licence="OTHER https://github.com/shinyquagsire23/OpenJKDF2/blob/master/LICENSE.md"
+rp_module_licence="CUSTOM https://raw.githubusercontent.com/shinyquagsire23/OpenJKDF2/master/LICENSE.md"
 rp_module_repo="git https://github.com/shinyquagsire23/OpenJKDF2.git v0.8.12"
 rp_module_section="exp"
 rp_module_flags="!all x86_64"

--- a/scriptmodules/ports/openrct2.sh
+++ b/scriptmodules/ports/openrct2.sh
@@ -12,7 +12,7 @@
 
 rp_module_id="openrct2"
 rp_module_desc="OpenRCT2 - RollerCoaster Tycoon 2 port"
-rp_module_licence="GNU https://github.com/OpenRCT2/OpenRCT2/blob/develop/licence.txt"
+rp_module_licence="GPL3 https://github.com/OpenRCT2/OpenRCT2/blob/develop/licence.txt"
 rp_module_help="Copy g1.dat, The 772 default RCT2 objects. /n/nEasy to identify by sorting on date, /n/nsince all 772 have a similar timestamp (usually from 2002 or 2003/n/n Required: If you use the OpenRCT2 title sequence, no scenarios are needed./n/n Six Flags Magic Mountain.SC6/n/n is needed for the RCT2 title sequence."
 rp_module_repo="git https://github.com/OpenRCT2/OpenRCT2.git develop 618c5bd"
 rp_module_section="exp"

--- a/scriptmodules/ports/pokerth.sh
+++ b/scriptmodules/ports/pokerth.sh
@@ -12,7 +12,7 @@
 
 rp_module_id="pokerth"
 rp_module_desc="pokerth is an open source online poker"
-rp_module_licence="https://github.com/GNOME/epiphany"
+rp_module_licence="AGPL https://github.com/pokerth/pokerth/blob/stable/COPYING"
 rp_module_section="exp"
 rp_module_flags="!mali !x86"
 

--- a/scriptmodules/ports/prboom-plus-system.sh
+++ b/scriptmodules/ports/prboom-plus-system.sh
@@ -12,7 +12,7 @@
 
 rp_module_id="prboom-plus-system"
 rp_module_desc="Doom/Doom II engine - Enhanced PRBoom Port"
-rp_module_licence="https://github.com/coelckers/prboom-plus"
+rp_module_licence="GPL2 https://github.com/coelckers/prboom-plus/blob/master/prboom2/COPYING"
 rp_module_repo="git https://github.com/coelckers/prboom-plus.git master"
 rp_module_section="exp"
 

--- a/scriptmodules/ports/prboom-plus.sh
+++ b/scriptmodules/ports/prboom-plus.sh
@@ -12,7 +12,7 @@
 
 rp_module_id="prboom-plus"
 rp_module_desc="Doom/Doom II engine - Enhanced PRBoom Port"
-rp_module_licence="https://github.com/coelckers/prboom-plus"
+rp_module_licence="GPL2 https://github.com/coelckers/prboom-plus/blob/master/prboom2/COPYING"
 rp_module_repo="git https://github.com/coelckers/prboom-plus.git master"
 rp_module_section="exp"
 

--- a/scriptmodules/ports/prototype.sh
+++ b/scriptmodules/ports/prototype.sh
@@ -13,7 +13,7 @@
 rp_module_id="prototype"
 rp_module_desc="ProtoType - an R-Type remake by Ron Bunce"
 rp_module_help="A keyboard is required to exit the game."
-rp_module_licence="freeware https://web.archive.org/web/20160507085617/http://xout.blackened-interactive.com/ProtoType/Prototype.html"
+rp_module_licence="FREEWARE https://web.archive.org/web/20160507085617/http://xout.blackened-interactive.com/ProtoType/Prototype.html"
 rp_module_repo="git https://github.com/ptitSeb/prototype.git master 12d2de8"
 rp_module_section="exp"
 rp_module_flags=""

--- a/scriptmodules/ports/quakespasm.sh
+++ b/scriptmodules/ports/quakespasm.sh
@@ -12,7 +12,7 @@
 
 rp_module_id="quakespasm"
 rp_module_desc="Quakespasm - Another enhanced engine for quake"
-rp_module_licence="GNU https://sourceforge.net/p/quakespasm/quakespasm/ci/master/tree/LICENSE.txt"
+rp_module_licence="GPL2 https://sourceforge.net/p/quakespasm/quakespasm/ci/master/tree/LICENSE.txt"
 rp_module_repo="git git://git.code.sf.net/p/quakespasm/quakespasm.git master"
 rp_module_section="exp"
 rp_module_flags="noinstclean"

--- a/scriptmodules/ports/rickyd.sh
+++ b/scriptmodules/ports/rickyd.sh
@@ -12,7 +12,7 @@
 
 rp_module_id="rickyd"
 rp_module_desc="rickyd - Port of Rick Dangerous"
-rp_module_licence="GPL https://sourceforge.net/p/rickyd/code/ci/master/tree/COPYING"
+rp_module_licence="GPL2 https://sourceforge.net/p/rickyd/code/ci/master/tree/COPYING"
 rp_module_repo="git git://git.code.sf.net/p/rickyd/code master"
 rp_module_section="exp"
 rp_module_flags="!mali !kms"

--- a/scriptmodules/ports/rigelengine.sh
+++ b/scriptmodules/ports/rigelengine.sh
@@ -13,7 +13,7 @@
 rp_module_id="rigelengine"
 rp_module_desc="RigelEngine - Duke Nukem 2 source port"
 rp_module_help="Copy your game to roms/ports/duke2 folder"
-rp_module_licence="GPL2 https://github.com/lethal-guitar/RigelEngine/blob/master/LICENSE.md"
+rp_module_licence="GPL2 https://raw.githubusercontent.com/lethal-guitar/RigelEngine/master/LICENSE.md"
 rp_module_repo="git https://github.com/lethal-guitar/RigelEngine.git v0.9.1"
 rp_module_section="exp"
 rp_module_flags="noinstclean"

--- a/scriptmodules/ports/rocksndiamonds.sh
+++ b/scriptmodules/ports/rocksndiamonds.sh
@@ -12,7 +12,7 @@
 
 rp_module_id="rocksndiamonds"
 rp_module_desc="Rocks'n'Diamonds - Emerald Mine Clone"
-rp_module_licence=" GNU https://git.artsoft.org/?p=rocksndiamonds.git;a=blob;f=COPYING;hb=HEAD"
+rp_module_licence="GPL2 https://git.artsoft.org/?p=rocksndiamonds.git;a=blob;f=COPYING;hb=HEAD"
 rp_module_repo="git https://git.artsoft.org/rocksndiamonds.git"
 rp_module_section="exp"
 rp_module_flags="!mali"

--- a/scriptmodules/ports/sqrxz2.sh
+++ b/scriptmodules/ports/sqrxz2.sh
@@ -12,7 +12,7 @@
 rp_module_id="sqrxz2"
 rp_module_desc="Sqrxz 2 - Two seconds until death by Retroguru"
 rp_module_help="Sqrxz 2 is a Jump'n'Run which requires a sharp mind and fast reflexes, high frustration is guaranteed."
-rp_module_licence="Retroguru http://www.retroguru.com/legal/"
+rp_module_licence="PROP http://www.retroguru.com/legal/"
 rp_module_section="opt"
 rp_module_flags="!x86 !mali"
 

--- a/scriptmodules/ports/sqrxz3.sh
+++ b/scriptmodules/ports/sqrxz3.sh
@@ -12,7 +12,7 @@
 rp_module_id="sqrxz3"
 rp_module_desc="Sqrxz 3 - Adventure For Love by Retroguru"
 rp_module_help="Sqrxz 3 is a Jump'n'Run which requires a sharp mind and fast reflexes, high frustration is guaranteed."
-rp_module_licence="Retroguru http://www.retroguru.com/legal/"
+rp_module_licence="PROP http://www.retroguru.com/legal/"
 rp_module_section="opt"
 rp_module_flags="!x86 !mali"
 

--- a/scriptmodules/ports/sqrxz4.sh
+++ b/scriptmodules/ports/sqrxz4.sh
@@ -12,7 +12,7 @@
 rp_module_id="sqrxz4"
 rp_module_desc="Sqrxz 4 - Cold Cash by Retroguru"
 rp_module_help="The fourth part of the quadrology Jump'n Think series Sqrxz brings you onto an cold icy island. Shiny marbles, evil penguins and ghosts, underwater creatures and many more to expect."
-rp_module_licence="Retroguru http://www.retroguru.com/legal/"
+rp_module_licence="PROP http://www.retroguru.com/legal/"
 rp_module_section="opt"
 rp_module_flags="!x86 !mali"
 

--- a/scriptmodules/ports/supaplex.sh
+++ b/scriptmodules/ports/supaplex.sh
@@ -12,7 +12,7 @@
 rp_module_id="supaplex"
 rp_module_desc="Reverse engineering Supaplex"
 rp_module_help="play the game"
-rp_module_licence="GNU https://www.gnu.org/licenses/gpl-3.0"
+rp_module_licence="CUSTOM https://github.com/sergiou87/open-supaplex/#license"
 rp_module_repo="file https://github.com/Exarkuniv/Rpi-pikiss-binary/raw/Master/open-supaplex-rpi.tar.gz"
 rp_module_section="exp"
 rp_module_flags="!armv6 rpi4"

--- a/scriptmodules/ports/temptations.sh
+++ b/scriptmodules/ports/temptations.sh
@@ -10,13 +10,13 @@
 #
 
 rp_module_id="temptations"
-rp_module_desc="Temptations - enhanced version of the MXS game"
+rp_module_desc="Temptations - Enhanced version of the MSX game"
 rp_module_help="F11 - Switches between Window and Full Screen.
- · G - Switches graphics between MSX Original and Nene Franz's new one.
- · L - Switches between Spanish and English language.
- · M - Switches Music off or on.
- · P - Pause."
-rp_module_licence="GNU https://www.gnu.org/licenses/gpl-3.0"
+ ï¿½ G - Switches graphics between MSX Original and Nene Franz's new one.
+ ï¿½ L - Switches between Spanish and English language.
+ ï¿½ M - Switches Music off or on.
+ ï¿½ P - Pause."
+rp_module_licence="GPL3 https://www.gnu.org/licenses/gpl-3.0"
 rp_module_repo="file https://github.com/Exarkuniv/Rpi-pikiss-binary/raw/Master/temptations-rpi.tar.gz"
 rp_module_section="exp"
 rp_module_flags="!armv6 rpi4"

--- a/scriptmodules/ports/vanillacc.sh
+++ b/scriptmodules/ports/vanillacc.sh
@@ -11,7 +11,7 @@
 
 rp_module_id="vanillacc"
 rp_module_desc="Vanilla-Command and Conquer"
-rp_module_licence="GNU https://github.com/TheAssemblyArmada/Vanilla-Conquer/blob/vanilla/License.txt"
+rp_module_licence="CUSTOM https://github.com/TheAssemblyArmada/Vanilla-Conquer/blob/vanilla/License.txt"
 rp_module_help="you will need to vist my github.com/Exarkuniv/Vanilla-Conquer=RPI for more info NOTE\n\ CCLOCAL.MIX needs to stay in tiberian dawn or the game will not run
 \nconquer.mix 	GDI or NOD disc: CONQUER.MIX\ndesert.mix 	GDI or NOD disc: DESERT.MIX\ntemperat.mix 	GDI or NOD disc: TEMPERAT.MIX\nwinter.mix 	GDI or NOD disc: WINTER.MIX\nsounds.mix 	GDI or NOD disc: SOUNDS.MIX\ncclocal.mix 	GDI or NOD disc, within: INSTALL/SETUP.Z\ntransit.mix 	GDI or NOD disc, within: INSTALL/SETUP.Z\nspeech.mix 	GDI or NOD disc, within: INSTALL/SETUP.Z\nupdate.mix 	GDI or NOD disc, within: INSTALL/SETUP.Z\nupdatec.mix 	GDI or NOD disc, within: INSTALL/SETUP.Z\ndeseicnh.mix 	GDI or NOD disc, within: INSTALL/SETUP.Z\ntempicnh.mix 	GDI or NOD disc, within: INSTALL/SETUP.Z\nwinticnh.mix 	GDI or NOD disc, within: INSTALL/SETUP.Z\ngdi/general.mix 	GDI disc: GENERAL.MIX\ngdi/movies.mix 	GDI disc: MOVIES.MIX\ngdi/scores.mix 	GDI disc: SCORES.MIX\nnod/general.mix 	NOD disc: GENERAL.MIX\nnod/movies.mix 	NOD disc: MOVIES.MIX\nnod/scores.mix 	NOD disc: SCORES.MIX"
 rp_module_repo="wget https://github.com/TheAssemblyArmada/Vanilla-Conquer/archive/refs/tags/latest.tar.gz"

--- a/scriptmodules/ports/vcmi.sh
+++ b/scriptmodules/ports/vcmi.sh
@@ -13,7 +13,7 @@
 rp_module_id="vcmi"
 rp_module_desc="Open-source engine for Heroes of Might and Magic III "
 rp_module_help="Copy Data, Maps and Mp3 from Heroes III to roms/ports/vcmi"
-rp_module_licence="GPL https://raw.githubusercontent.com/vcmi/vcmi/develop/license.txt"
+rp_module_licence="GPL2 https://raw.githubusercontent.com/vcmi/vcmi/develop/license.txt"
 rp_module_section="exp"
 rp_module_flags="!mali"
 

--- a/scriptmodules/ports/xump.sh
+++ b/scriptmodules/ports/xump.sh
@@ -12,7 +12,7 @@
 rp_module_id="xump"
 rp_module_desc="Xump - The Final Run"
 rp_module_help="Xump - The Final Run is a simple multi-platform puzzler by Retroguru. Help Holger to clean up deserted space fields. As this is a very dangerous task for a human being a headbot named Xump will be the one who has to suffer."
-rp_module_licence="Retroguru http://www.retroguru.com/legal/"
+rp_module_licence="PROP http://www.retroguru.com/legal/"
 rp_module_section="opt"
 rp_module_flags="!x86 !mali"
 

--- a/scriptmodules/ports/zeldansq.sh
+++ b/scriptmodules/ports/zeldansq.sh
@@ -12,7 +12,7 @@
 
 rp_module_id="zeldansq"
 rp_module_desc="zeldansq - Zelda Navi's Quest fangame"
-rp_module_licence="Unknown"
+rp_module_licence="UNKNOWN http://www.zeldaroth.fr/"
 rp_module_help=""
 rp_module_repo="file http://www.zeldaroth.fr/fichier/NSQ/linux/ZeldaNSQ-src-linux.zip"
 rp_module_section="exp"

--- a/scriptmodules/supplementary/audacity.sh
+++ b/scriptmodules/supplementary/audacity.sh
@@ -12,7 +12,7 @@
 
 rp_module_id="audacity"
 rp_module_desc="Audacity open-source digital audio editor"
-rp_module_licence="https://www.audacityteam.org"
+rp_module_licence="GPL2 https://www.audacityteam.org/about/license/"
 rp_module_section="exp"
 rp_module_flags="!mali !x86"
 

--- a/scriptmodules/supplementary/epiphany.sh
+++ b/scriptmodules/supplementary/epiphany.sh
@@ -12,7 +12,7 @@
 
 rp_module_id="epiphany"
 rp_module_desc="epiphany lightweight web browser"
-rp_module_licence="https://github.com/GNOME/epiphany"
+rp_module_licence="GPL3 https://github.com/GNOME/epiphany"
 rp_module_section="exp"
 rp_module_flags="!mali !x86"
 

--- a/scriptmodules/supplementary/filezilla.sh
+++ b/scriptmodules/supplementary/filezilla.sh
@@ -12,7 +12,7 @@
 
 rp_module_id="filezilla"
 rp_module_desc="A cross platform FTP application"
-rp_module_licence="https://filezilla-project.org"
+rp_module_licence="GPL2 https://svn.filezilla-project.org/filezilla/FileZilla3/trunk/COPYING?view=markup"
 rp_module_section="exp"
 rp_module_flags="!mali !x86"
 

--- a/scriptmodules/supplementary/gparted.sh
+++ b/scriptmodules/supplementary/gparted.sh
@@ -12,7 +12,7 @@
 
 rp_module_id="gparted"
 rp_module_desc="partition editing application"
-rp_module_licence="https://gparted.org"
+rp_module_licence="GPL2 https://gparted.org"
 rp_module_section="exp"
 rp_module_flags="!mali !x86"
 

--- a/scriptmodules/supplementary/kodi-extra.sh
+++ b/scriptmodules/supplementary/kodi-extra.sh
@@ -12,7 +12,7 @@
 
 rp_module_id="kodi-extra"
 rp_module_desc="Kodi - Open source home theatre software"
-rp_module_licence="GPL2 https://raw.githubusercontent.com/xbmc/xbmc/master/LICENSE.GPL"
+rp_module_licence="GPL2 https://raw.githubusercontent.com/xbmc/xbmc/master/LICENSE.md"
 rp_module_section="exp"
 rp_module_flags="!mali"
 

--- a/scriptmodules/supplementary/librecad.sh
+++ b/scriptmodules/supplementary/librecad.sh
@@ -12,7 +12,7 @@
 
 rp_module_id="librecad"
 rp_module_desc="librecad open-source 2d cad"
-rp_module_licence="https://www.audacityteam.org"
+rp_module_licence="GPL2 https://github.com/LibreCAD/LibreCAD/tree/master/licenses"
 rp_module_section="exp"
 rp_module_flags="!mali !x86"
 

--- a/scriptmodules/supplementary/libreoffice.sh
+++ b/scriptmodules/supplementary/libreoffice.sh
@@ -12,7 +12,7 @@
 
 rp_module_id="libreoffice"
 rp_module_desc="Open source office suite"
-rp_module_licence="https://www.libreoffice.org"
+rp_module_licence="MPL2 https://www.libreoffice.org/get-help/frequently-asked-questions/#whyfree"
 rp_module_section="exp"
 rp_module_flags="!mali !x86"
 

--- a/scriptmodules/supplementary/mixxx.sh
+++ b/scriptmodules/supplementary/mixxx.sh
@@ -12,7 +12,7 @@
 
 rp_module_id="mixxx"
 rp_module_desc="Mixxx DJ Mixing Software App"
-rp_module_licence="www.mixxx.org"
+rp_module_licence="GPL2 https://github.com/mixxxdj/mixxx/blob/main/LICENSE"
 rp_module_section="exp"
 rp_module_flags="!mali !x86"
 

--- a/scriptmodules/supplementary/mypaint.sh
+++ b/scriptmodules/supplementary/mypaint.sh
@@ -12,7 +12,7 @@
 
 rp_module_id="mypaint"
 rp_module_desc="mypaint easy-to-use painting program"
-rp_module_licence="mypaint.org"
+rp_module_licence="GPL2 https://github.com/mypaint/mypaint/blob/master/COPYING"
 rp_module_section="exp"
 rp_module_flags="!mali !x86"
 

--- a/scriptmodules/supplementary/omxplayer.sh
+++ b/scriptmodules/supplementary/omxplayer.sh
@@ -13,7 +13,7 @@
 rp_module_id="omxplayer"
 rp_module_desc="omxplayer - Video Player"
 rp_module_help="Put your videos into $"
-rp_module_licence="GPL2 https://www.gnu.org/licenses/gpl-2.0.txt"
+rp_module_licence="GPL2 https://github.com/popcornmix/omxplayer/blob/master/COPYING"
 rp_module_section="exp"
 rp_module_flags="!mali !x86"
 

--- a/scriptmodules/supplementary/putty.sh
+++ b/scriptmodules/supplementary/putty.sh
@@ -12,7 +12,7 @@
 
 rp_module_id="putty"
 rp_module_desc="SSH and telnet client"
-rp_module_licence="https://www.putty.org"
+rp_module_licence="MIT https://www.chiark.greenend.org.uk/~sgtatham/putty/licence.html"
 rp_module_section="exp"
 rp_module_flags="!mali !x86"
 

--- a/scriptmodules/supplementary/retroscraper.sh
+++ b/scriptmodules/supplementary/retroscraper.sh
@@ -11,7 +11,7 @@
 
 rp_module_id="retroscraper"
 rp_module_desc="Scraper for EmulationStation by kiro"
-rp_module_licence="GNU https://github.com/zayamatias/retroscraper-rpie/blob/main/LICENSE"
+rp_module_licence="GPL2 https://github.com/zayamatias/retroscraper-rpie/blob/main/LICENSE"
 rp_module_repo="git https://github.com/zayamatias/retroscraper-rpie.git main"
 rp_module_section="exp"
 

--- a/scriptmodules/supplementary/vlc.sh
+++ b/scriptmodules/supplementary/vlc.sh
@@ -12,7 +12,7 @@
 
 rp_module_id="vlc"
 rp_module_desc="VLC media player"
-rp_module_licence="https://www.videolan.org"
+rp_module_licence="GPL2 https://www.videolan.org/vlc"
 rp_module_section="exp"
 rp_module_flags="!mali !x86"
 


### PR DESCRIPTION
This aligns the license header information from `rp_module_licence=` to be more RetroPie-Setup alike by using the same key for commonly used licences.

BTW: Is there a reason you put this repo at MIT licence while the RetroPie-Setup uses GPL3? Why not relicence to GPL3 as it grants more freedom?