### PR TITLE
[lr-vircon32] Patch to allow Buster builds and OpenGLES usage

### DIFF
--- a/scriptmodules/libretrocores/lr-vircon32.sh
+++ b/scriptmodules/libretrocores/lr-vircon32.sh
@@ -15,15 +15,23 @@ rp_module_help="ROM Extensions: .v32 .zip\n\nCopy your roms to $romdir/vircon32\
 rp_module_licence="3-Clause BSD https://raw.githubusercontent.com/vircon32/vircon32-libretro/main/LICENSE.md"
 rp_module_repo="git https://github.com/vircon32/vircon32-libretro.git main"
 rp_module_section="exp"
-rp_module_flags="!all 64bit"
+rp_module_flags="!all rpi3 rpi4 rpi5 x86"
 
 function sources_lr-vircon32() {
     gitPullOrClone
+    local cmake_ver
+    cmake_ver=$(cmake --version | head -n 1 | cut -f 3 -d ' ')
+    if dpkg --compare-versions "${cmake_ver}" lt 3.17 ; then
+        # for OS with cmake less than 3.17 (missing: foreach(<loop_var>... IN ZIP_LISTS <lists>))
+        applyPatch "$md_data/cmake_pre3.17.patch"
+    fi
 }
 
 function build_lr-vircon32() {
-	cmake .
-    make
+    local defines=()
+    isPlatform "gles" && defines+=("-DENABLE_OPENGLES2=1")
+    cmake "${defines[@]}" .
+    make -j$(nproc)
     md_ret_require="$md_build/vircon32_libretro.so"
 }
 

--- a/scriptmodules/libretrocores/lr-vircon32/cmake_pre3.17.patch
+++ b/scriptmodules/libretrocores/lr-vircon32/cmake_pre3.17.patch
@@ -1,0 +1,55 @@
+diff --git a/embed-binaries/embed-binaries.cmake b/embed-binaries/embed-binaries.cmake
+index d46353e..1f54841 100644
+--- a/embed-binaries/embed-binaries.cmake
++++ b/embed-binaries/embed-binaries.cmake
+@@ -1,7 +1,3 @@
+-cmake_minimum_required(VERSION
+-	3.17.5 # foreach(loop-var... IN ZIP_LISTS <lists>...)
+-)
+-
+ include_guard()
+ 
+ function(generate_code_to_embed_binary asset_name asset_path byte_type constexpr null_terminate out_generated_header out_generated_implementation)
+@@ -145,12 +141,17 @@ function(embed_binaries target_name)
+ 			list(APPEND asset_${param_name}s ${asset_${param_name}})
+ 		endforeach()
+ 
+-		foreach(param_name default_value IN ZIP_LISTS asset_optional_args asset_optional_args_defaults)
+-			if (NOT DEFINED asset_${param_name})
+-				set(asset_${param_name} ${default_value})
++		list(LENGTH asset_optional_args _alen)
++		math(EXPR alen "${_alen} - 1")
++
++		foreach(i RANGE ${alen})
++			list(GET asset_optional_args ${i} arg_key)
++			list(GET asset_optional_args_defaults ${i} arg_dflt_val)
++			if (NOT DEFINED asset_${arg_key})
++				set(asset_${arg_key} ${arg_dflt_val})
+ 			endif()
+ 
+-			list(APPEND asset_${param_name}s ${asset_${param_name}})
++			list(APPEND asset_${arg_key}s ${asset_${arg_key}})
+ 		endforeach()
+ 	endwhile()
+ 
+@@ -173,10 +174,16 @@ function(embed_binaries target_name)
+ 		target_compile_features("${target_name}" INTERFACE cxx_constexpr)
+ 	endif()
+ 
+-	foreach(
+-		asset_NAME asset_PATH asset_CONSTEXPR asset_BYTE_TYPE asset_NULL_TERMINATE
+-		IN ZIP_LISTS
+-		asset_NAMEs asset_PATHs asset_CONSTEXPRs asset_BYTE_TYPEs asset_NULL_TERMINATEs)
++	list(LENGTH asset_NAMEs _nlen)
++	math(EXPR nlen "${_nlen} - 1")
++
++	foreach(i RANGE ${nlen})
++		list(GET asset_NAMEs ${i} asset_NAME)
++		list(GET asset_PATHs ${i} asset_PATH)
++		list(GET asset_CONSTEXPRs ${i} asset_CONSTEXPR)
++		list(GET asset_BYTE_TYPEs ${i} asset_BYTE_TYPE)
++		list(GET asset_NULL_TERMINATEs ${i} asset_NULL_TERMINATE)
++
+ 		string(MAKE_C_IDENTIFIER "${asset_NAME}" asset_name_identifier)
+ 
+ 		get_filename_component(asset_PATH ${asset_PATH} ABSOLUTE)


### PR DESCRIPTION
* enable building on Buster (due to cmake 3.16.3 and missing foreach in zip_lists) 
* use OpenGLES instead of OpenGL on GLES capable platforms