### PR TITLE
DICE emulator for machines without a CPU.

### DIFF
--- a/scriptmodules/libretrocores/lr-dice.sh
+++ b/scriptmodules/libretrocores/lr-dice.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# This file is part of The RetroPie Project
+#
+# The RetroPie Project is the legal property of its developers, whose names are
+# too numerous to list here. Please refer to the COPYRIGHT.md file distributed with this source.
+#
+# See the LICENSE.md file at the top-level directory of this distribution and
+# at https://raw.githubusercontent.com/RetroPie/RetroPie-Setup/master/LICENSE.md
+#
+
+rp_module_id="lr-dice"
+rp_module_desc="Discrete Integrated Circuit Emulator for machines without a CPU - DICE core for libretro"
+rp_module_help="ROM Extensions: .zip .dmy .k1 .a1 .6c .c6 .d2 .s1 .f4 .a4 .1da .da1 .C4 .4c .4d .d7 .d4\n\nCopy your DICE TTL roms to $romdir/dice"
+rp_module_licence="GPL3 https://raw.githubusercontent.com/mittonk/dice-libretro/main/LICENSE.txt"
+rp_module_repo="git https://github.com/mittonk/dice-libretro.git main"
+rp_module_section="exp"
+
+function depends_lr-dice() {
+    getDepends zip
+}
+
+function sources_lr-dice() {
+    gitPullOrClone
+}
+
+function build_lr-dice() {
+    make clean
+    make
+    md_ret_require="$md_build/dice_libretro.so"
+}
+
+function install_lr-dice() {
+    md_ret_files=(
+        'README.md'
+        'dice_libretro.so'
+        'LICENSE.txt'
+    )
+}
+
+function configure_lr-dice() {
+    mkRomDir "dice"
+    defaultRAConfig "dice"
+
+    addEmulator 0 "$md_id" "dice" "$md_inst/dice_libretro.so"
+    addSystem "dice"
+}

--- a/scriptmodules/libretrocores/lr-dice.sh
+++ b/scriptmodules/libretrocores/lr-dice.sh
@@ -17,7 +17,7 @@ rp_module_repo="git https://github.com/mittonk/dice-libretro.git main"
 rp_module_section="exp"
 
 function depends_lr-dice() {
-    getDepends zip
+    getDepends zlib1g-dev
 }
 
 function sources_lr-dice() {

--- a/scriptmodules/libretrocores/lr-dice.sh
+++ b/scriptmodules/libretrocores/lr-dice.sh
@@ -11,7 +11,7 @@
 
 rp_module_id="lr-dice"
 rp_module_desc="Discrete Integrated Circuit Emulator for machines without a CPU - DICE core for libretro"
-rp_module_help="ROM Extensions: .zip .dmy .k1 .a1 .6c .c6 .d2 .s1 .f4 .a4 .1da .da1 .C4 .4c .4d .d7 .d4\n\nCopy your DICE TTL roms to $romdir/dice"
+rp_module_help="ROM Extensions: .zip .dmy\n\nCopy your DICE TTL roms to either $romdir/arcade or $romdir/dice"
 rp_module_licence="GPL3 https://raw.githubusercontent.com/mittonk/dice-libretro/main/LICENSE.txt"
 rp_module_repo="git https://github.com/mittonk/dice-libretro.git main"
 rp_module_section="exp"
@@ -39,9 +39,11 @@ function install_lr-dice() {
 }
 
 function configure_lr-dice() {
-    mkRomDir "dice"
-    defaultRAConfig "dice"
-
-    addEmulator 0 "$md_id" "dice" "$md_inst/dice_libretro.so"
-    addSystem "dice"
+    local system
+    for system in arcade dice; do
+        mkRomDir "$system"
+        defaultRAConfig "$system"
+        addEmulator 0 "$md_id" "$system" "$md_inst/dice_libretro.so"
+        addSystem "$system"
+    done
 }

--- a/scriptmodules/libretrocores/lr-dice.sh
+++ b/scriptmodules/libretrocores/lr-dice.sh
@@ -44,6 +44,9 @@ function configure_lr-dice() {
         mkRomDir "$system"
         defaultRAConfig "$system"
         addEmulator 0 "$md_id" "$system" "$md_inst/dice_libretro.so"
-        addSystem "$system"
     done
+    addSystem "arcade"
+    # Supply fullname and extensions for platform DICE.  Doesn't configure
+    # scraper to use platform "arcade", but close enough.
+    addSystem "dice" "DICE" ".zip .dmy"
 }


### PR DESCRIPTION
Builds and runs on a RPi 4 (Bookworm 64).
Builds and runs on a RPi Zero 2w (official RetroPie image, Buster 32).
(Unusably slow on a RPi B+.)

No targeted database/scraper yet.  1-2 games match using the "arcade" scraper config.
~~No theme yet~~ Basic theme in [es-theme-carbon-2021](https://github.com/RetroPie/es-theme-carbon-2021).

.zip files work in either `roms/arcade` or `roms/dice`.  .dmy files only work in `roms/dice`.