### PR TITLE
lr-pd777: zipfile support and zlib dependency

### DIFF
--- a/scriptmodules/libretrocores/lr-pd777.sh
+++ b/scriptmodules/libretrocores/lr-pd777.sh
@@ -11,10 +11,14 @@
 
 rp_module_id="lr-pd777"
 rp_module_desc="Epoch Cassette Vision emulator - PD777 port for libretro"
-rp_module_help="ROM Extensions: .bin777\n\nCopy your PD777 roms to $romdir/cassettevision"
+rp_module_help="ROM Extensions: .zip .bin777\n\nCopy your PD777 roms to $romdir/cassettevision"
 rp_module_licence="MIT https://raw.githubusercontent.com/mittonk/PD777/refs/heads/main/LICENSE"
 rp_module_repo="git https://github.com/mittonk/PD777.git main"
 rp_module_section="exp"
+
+function depends_lr-pd777() {
+    getDepends zlib1g-dev
+}
 
 function sources_lr-pd777() {
     gitPullOrClone
@@ -39,5 +43,5 @@ function configure_lr-pd777() {
     mkRomDir "cassettevision"
     defaultRAConfig "cassettevision"
     addEmulator 0 "$md_id" "cassettevision" "$md_inst/pd777_libretro.so"
-    addSystem "cassettevision" "Cassette Vision" ".bin777"
+    addSystem "cassettevision" "Cassette Vision" ".zip .bin777"
 }


### PR DESCRIPTION
Add ZIP support (and zlib depenency).

Test on Raspberry Pi 4, Bookworm 64.