### PR TITLE
Adding Dune Dynasty, another port of Dune II

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 # Auto detect text files and perform LF normalization
-* text=auto
+* text=eol=lf
 
 # don't convert .diff or .patch files
 *.diff binary

--- a/scriptmodules/ports/dunedynasty.sh
+++ b/scriptmodules/ports/dunedynasty.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+# This file is part of RetroPie-Extra, a supplement to RetroPie.
+# For more information, please visit:
+#
+# https://github.com/RetroPie/RetroPie-Setup
+# https://github.com/Exarkuniv/RetroPie-Extra
+#
+# See the LICENSE file distributed with this source and at
+# https://raw.githubusercontent.com/Exarkuniv/RetroPie-Extra/master/LICENSE
+#
+
+rp_module_id="dunedynasty"
+rp_module_desc="Dune Dynasty - Dune 2 port"
+rp_module_help="Please put your data files from Dune II v1.07 EU only in the roms/ports/dunedynasty/data folder.
+
+Dune II has been classified as abandonware, the install script will take care of the data files. Please enjoy!"
+rp_module_licence="GNU https://github.com/gameflorist/dunedynasty/LICENSE.txt"
+rp_module_repo="git https://github.com/gameflorist/dunedynasty.git master"
+rp_module_section="exp"
+rp_module_flags="!all rpi4 rpi5"
+
+
+function depends_dunedynasty() {
+   getDepends build-essential cmake liballegro5-dev libenet-dev libmad0-dev libfluidsynth-dev fluidsynth patchelf
+}
+
+
+function sources_dunedynasty() {
+    gitPullOrClone
+}
+
+function build_dunedynasty() {
+    cmake -DCMAKE_BUILD_TYPE=Release .
+    make
+    mkdir dist/libs
+    (ldd ./dist/dunedynasty | grep -E 'libfluidsynth' |awk '{if(substr($3,0,1)=="/") print $1,$3}' |sort) |cut -d\  -f2 |
+    xargs -d '\n' -I{} cp --copy-contents {} ./dist/libs
+    ls -1 ./dist/libs/ | while read file
+    do
+        patchelf --remove-needed $file ./dist/dunedynasty
+        patchelf --add-needed $md_inst/libs/$file ./dist/dunedynasty
+    done
+
+    md_ret_require="$md_build/dist/dunedynasty"
+}
+
+function install_dunedynasty() {
+    md_ret_files=(
+        'dist/campaign'
+        'dist/data'
+        'dist/gfx'
+        'dist/libs'
+        'dist/licences'
+        'dist/music'
+        'dist/dunedynasty'
+        'dist/dunedynasty.cfg-sample'
+        'dist/LICENSE.txt'
+        'dist/README.txt'
+    )
+}
+
+function game_data_dunedynasty() {
+
+    if [[ ! -f "$romdir/ports/dunedynasty/data/DUNE.PAK" ]]; then
+        downloadAndExtract "https://github.com/er-tho/game-data/raw/main/dune-II-1.07eu.zip" "$romdir/ports/dunedynasty/data"
+    chown -R $__user:$__group "$romdir/ports/dunedynasty"
+    fi
+}
+
+function configure_dunedynasty() {
+    mkRomDir "ports/dunedynasty/data"
+    addPort "$md_id" "dunedynasty" "Dune Dynasty" "XINIT: $md_inst/dunedynasty"
+	rm -r $md_inst/data
+	ln -snf "$romdir/ports/dunedynasty/data" "$md_inst"
+
+    [[ "$md_mode" == "install" ]] && game_data_dunedynasty
+}

--- a/scriptmodules/ports/dunedynasty.sh
+++ b/scriptmodules/ports/dunedynasty.sh
@@ -22,7 +22,7 @@ rp_module_flags="!all rpi4 rpi5"
 
 
 function depends_dunedynasty() {
-   getDepends build-essential cmake liballegro5-dev libenet-dev libmad0-dev libfluidsynth-dev fluidsynth patchelf
+   getDepends build-essential cmake liballegro5-dev libenet-dev libmad0-dev libfluidsynth-dev fluidsynth libgl1 patchelf liballegro-acodec5-dev liballegro-audio5-dev liballegro-image5-dev
 }
 
 


### PR DESCRIPTION
Here is a script to install Dune Dynasty, building it from sources.
Tested on Rpi 5 with Trixie but the requierements suggest that it should work on Pi4 and previous distrib, bookworm.
I dont have other RetroPie on older machine/older distrib ready to make other tests, so I will let other do that.

One note: the Dune II data files you have on your game-data repo can't be used for this port as it works only with v1.07 EU (full list of needed files with their corresponding md5sum can be found on the official repo of Dune Dynasty here: https://github.com/gameflorist/dunedynasty/blob/master/static/general/data/FILELIST.TXT)
So I forked your game-data repo to add an archive with those files (function game_data_dunedynasty()). 
To keep it consistent with all the other ports, it would probably be be better that you download this zip file to add it to your repo (or I go do a pull request there too).

Final Note:
As you can see, the commit includes my .gitattributes. I don't know how to do to not include it... I had to push it on my master branch because I'm on a Windows environment and so Github Desktop is automatically changing end of lines as CRLF because of the parameter text=auto on your .gitattributes. If I dont change it it completely mess up my files. My change force to keep EOL as LF, which in my opinion should be the default for this repo, as it is destined to a linux environment. So it's up to you to decide what to do about that, but all of the pull requests I will do will include it as it seems I have no solution to not include it...
I already have another new game to add ready and some changes for a few scripts. I will wait to see your answer about it.