### PR TITLE
Enable compilation on rpi4 and add rpi4 64bit check

### DIFF
--- a/scriptmodules/ports/xash3d-fwgs.sh
+++ b/scriptmodules/ports/xash3d-fwgs.sh
@@ -13,11 +13,13 @@ rp_module_id="xash3d-fwgs"
 rp_module_desc="xash3d-fwgs - Half-Life Engine Port"
 rp_module_help="Please add your full version Half-Life data files (folders /valve, /bshift and /gearbox) to $romdir/ports/xash3d-fwgs/ to play."
 rp_module_section="exp"
-rp_module_flags="!mali !x86 !all rpi5"
+rp_module_flags="!mali !x86 !all rpi5 rpi4"
 
 
 function _arch_xash3d() {
     if isPlatform "rpi5"; then
+        echo arm64
+    elif isPlatform "rpi4" && isPlatform "64bit"; then
         echo arm64
     else
         echo armv8_32hf


### PR DESCRIPTION
This PR enables compilation for the xash3d-fwgs module on the Raspberry Pi 4. It adds rpi4 to the module flags and introduces an elif condition to correctly set the architecture to arm64 when running on a Raspberry Pi 4 with a 64-bit operating system.

Half-Life 1 is indeed running smooth on a rpi4. :)